### PR TITLE
Data generation workflows for Train Ticket

### DIFF
--- a/collectors/metrics/bin/get_metrics_from_prom.py
+++ b/collectors/metrics/bin/get_metrics_from_prom.py
@@ -54,7 +54,7 @@ def support_set_default(obj: set):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--target",
-                        choices=['sockshop', 'trainticket'], default='sockshop',
+                        choices=[sockshop.TARGET_APP_NAME, trainticket.TARGET_APP_NAME], default=sockshop.TARGET_APP_NAME,
                         help="target application to collect metrics")
     parser.add_argument("--prometheus-url",
                         help="endpoint URL for prometheus server",
@@ -75,7 +75,7 @@ def main():
     args = parser.parse_args()
 
     match args.target:
-        case 'sock-shop':
+        case sockshop.TARGET_APP_NAME:
             try:
                 result: dict[str, Any] = sockshop.collect_metrics(
                     prometheus_url=args.prometheus_url,
@@ -93,7 +93,7 @@ def main():
                 print("parsing timestamp error:", e, file=sys.stderr)
                 parser.print_help()
                 exit(-1)
-        case 'train-ticket':
+        case trainticket.TARGET_APP_NAME:
             result = trainticket.collect_metrics(
                 prometheus_url=args.prometheus_url,
                 grafana_url=args.grafana_url,

--- a/collectors/metrics/bin/get_metrics_from_prom.py
+++ b/collectors/metrics/bin/get_metrics_from_prom.py
@@ -75,7 +75,7 @@ def main():
     args = parser.parse_args()
 
     match args.target:
-        case 'sockshop':
+        case 'sock-shop':
             try:
                 result: dict[str, Any] = sockshop.collect_metrics(
                     prometheus_url=args.prometheus_url,
@@ -93,7 +93,7 @@ def main():
                 print("parsing timestamp error:", e, file=sys.stderr)
                 parser.print_help()
                 exit(-1)
-        case 'trainticket':
+        case 'train-ticket':
             result = trainticket.collect_metrics(
                 prometheus_url=args.prometheus_url,
                 grafana_url=args.grafana_url,

--- a/collectors/metrics/targets/sockshop.py
+++ b/collectors/metrics/targets/sockshop.py
@@ -3,6 +3,7 @@ from typing import Any
 from prometheus.fetcher import PromFetcher
 from tsutil import tsutil
 
+TARGET_APP_NAME = 'sock-shop'
 COMPONENT_LABELS = {
     "front-end", "orders", "orders-db", "carts", "carts-db",
     "shipping", "user", "user-db", "payment", "catalogue", "catalogue-db",

--- a/collectors/metrics/targets/trainticket.py
+++ b/collectors/metrics/targets/trainticket.py
@@ -4,6 +4,7 @@ from typing import Any
 from prometheus.fetcher import PromFetcher
 from tsutil import tsutil
 
+TARGET_APP_NAME = 'train-ticket'
 APP_LABEL = 'train-ticket'
 APP_NODEPOOL = 'default-pool'
 GRAFANA_DASHBOARD = ''

--- a/collectors/metrics/targets/trainticket.py
+++ b/collectors/metrics/targets/trainticket.py
@@ -84,7 +84,7 @@ def metrics_as_result(
             continue
         # TODO: want to rename 'kubernetes-name' in prometheus config because it is not intuitive.
         # sockshop is 'kubernetes_name', but trainticket is 'app'.
-        container = metric['metric'].get('kubernetes_name', metric['metric']['app'])
+        container = metric['metric'].get('kubernetes_name', metric['metric']['app_kubernetes_io_name'])
         data['middlewares'].setdefault(container, [])
         values = tsutil.interpotate_time_series(metric['values'], time_meta)
         m = {
@@ -172,7 +172,7 @@ def collect_metrics(
     assert len(container_metrics) != 0
 
     # get pod metrics
-    pod_selector = 'app=~"ts-.+",kubernetes_namespace="train-ticket"'
+    pod_selector = 'app_kubernetes_io_name=~"ts-.+",kubernetes_namespace="train-ticket"'
     pod_targets = fetcher.request_targets(pod_selector)
     pod_metrics = fetcher.get_metrics(pod_targets, pod_selector)
     assert len(pod_metrics) != 0

--- a/manifests/sock-shop-base/README.md
+++ b/manifests/sock-shop-base/README.md
@@ -75,7 +75,7 @@ $ kubectl annotate serviceaccount --namespace litmus argo-chaos iam.gke.io/gcp-s
 1. Prepare to access Litmus 2.0 Portal.
 
 ```shell-session
-$ kubectl port-forward svc/litmusportal-frontend-service -n litmus --address 0.0.0.0 9091:9091
+$ kubectl port-forward svc/chaos-litmus-frontend-service -n litmus --address 0.0.0.0 9091:9091
 ```
 
 2. Access and Login <http://localhost:9091> with username/password: `admin/litmus` <https://litmuschaos.github.io/tutorials/tutorial-getting-started/index.html#2>.

--- a/manifests/sock-shop-base/sock-shop/carts-db-dep.yaml
+++ b/manifests/sock-shop-base/sock-shop/carts-db-dep.yaml
@@ -4,7 +4,9 @@ kind: Deployment
 metadata:
   name: carts-db
   labels:
-    name: carts-db
+    app.kubernetes.io/name: carts-db
+    app.kubernetes.io/part-of: carts
+    app.kubernetes.io/component: db
     app: sock-shop
   namespace: sock-shop
   annotations:
@@ -13,12 +15,16 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      name: carts-db
+      app.kubernetes.io/name: carts-db
+      app.kubernetes.io/part-of: carts
+      app.kubernetes.io/component: db
       app: sock-shop
   template:
     metadata:
       labels:
-        name: carts-db
+        app.kubernetes.io/name: carts-db
+        app.kubernetes.io/part-of: carts
+        app.kubernetes.io/component: db
         app: sock-shop
       annotations:
         prometheus.io/scrape: "true"

--- a/manifests/sock-shop-base/sock-shop/carts-db-svc.yaml
+++ b/manifests/sock-shop-base/sock-shop/carts-db-svc.yaml
@@ -4,7 +4,9 @@ kind: Service
 metadata:
   name: carts-db
   labels:
-    name: carts-db
+    app.kubernetes.io/name: carts-db
+    app.kubernetes.io/part-of: carts
+    app.kubernetes.io/component: db
     app: sock-shop
   namespace: sock-shop
 spec:
@@ -13,5 +15,7 @@ spec:
   - port: 27017
     targetPort: 27017
   selector:
-    name: carts-db
+    app.kubernetes.io/name: carts-db
+    app.kubernetes.io/part-of: carts
+    app.kubernetes.io/component: db
     app: sock-shop

--- a/manifests/sock-shop-base/sock-shop/carts-dep.yaml
+++ b/manifests/sock-shop-base/sock-shop/carts-dep.yaml
@@ -4,7 +4,9 @@ kind: Deployment
 metadata:
   name: carts
   labels:
-    name: carts
+    app.kubernetes.io/name: carts
+    app.kubernetes.io/part-of: carts
+    app.kubernetes.io/component: web
     app: sock-shop
   annotations:
     litmuschaos.io/chaos: "true"
@@ -13,12 +15,16 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      name: carts
+      app.kubernetes.io/name: carts
+      app.kubernetes.io/part-of: carts
+      app.kubernetes.io/component: web
       app: sock-shop
   template:
     metadata:
       labels:
-        name: carts
+        app.kubernetes.io/name: carts
+        app.kubernetes.io/part-of: carts
+        app.kubernetes.io/component: web
         app: sock-shop
     spec:
       containers:

--- a/manifests/sock-shop-base/sock-shop/carts-svc.yaml
+++ b/manifests/sock-shop-base/sock-shop/carts-svc.yaml
@@ -4,7 +4,9 @@ kind: Service
 metadata:
   name: carts
   labels:
-    name: carts
+    app.kubernetes.io/name: carts
+    app.kubernetes.io/part-of: carts
+    app.kubernetes.io/component: web
     app: sock-shop
   namespace: sock-shop
 spec:
@@ -13,5 +15,7 @@ spec:
   - port: 80
     targetPort: 80
   selector:
-    name: carts
+    app.kubernetes.io/name: carts
+    app.kubernetes.io/part-of: carts
+    app.kubernetes.io/component: web
     app: sock-shop

--- a/manifests/sock-shop-base/sock-shop/catalogue-db-dep.yaml
+++ b/manifests/sock-shop-base/sock-shop/catalogue-db-dep.yaml
@@ -4,7 +4,9 @@ kind: Deployment
 metadata:
   name: catalogue-db
   labels:
-    name: catalogue-db
+    app.kubernetes.io/name: catalogue-db
+    app.kubernetes.io/part-of: catalogue
+    app.kubernetes.io/component: db
     app: sock-shop
   annotations:
     litmuschaos.io/chaos: "true"
@@ -13,12 +15,16 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      name: catalogue-db
+      app.kubernetes.io/name: catalogue-db
+      app.kubernetes.io/part-of: catalogue
+      app.kubernetes.io/component: db
       app: sock-shop
   template:
     metadata:
       labels:
-        name: catalogue-db
+        app.kubernetes.io/name: catalogue-db
+        app.kubernetes.io/part-of: catalogue
+        app.kubernetes.io/component: db
         app: sock-shop
       annotations:
         prometheus.io/scrape: "true"

--- a/manifests/sock-shop-base/sock-shop/catalogue-dep.yaml
+++ b/manifests/sock-shop-base/sock-shop/catalogue-dep.yaml
@@ -4,7 +4,9 @@ kind: Deployment
 metadata:
   name: catalogue
   labels:
-    name: catalogue
+    app.kubernetes.io/name: catalogue
+    app.kubernetes.io/part-of: catalogue
+    app.kubernetes.io/component: web
     app: sock-shop
   annotations:
     litmuschaos.io/chaos: "true"

--- a/manifests/sock-shop-base/sock-shop/catalogue-svc.yaml
+++ b/manifests/sock-shop-base/sock-shop/catalogue-svc.yaml
@@ -4,7 +4,9 @@ kind: Service
 metadata:
   name: catalogue
   labels:
-    name: catalogue
+    app.kubernetes.io/name: catalogue
+    app.kubernetes.io/part-of: catalogue
+    app.kubernetes.io/component: web
     app: sock-shop
   namespace: sock-shop
 spec:
@@ -13,5 +15,7 @@ spec:
   - port: 80
     targetPort: 80
   selector:
-    name: catalogue
+    app.kubernetes.io/name: catalogue
+    app.kubernetes.io/part-of: catalogue
+    app.kubernetes.io/component: web
     app: sock-shop

--- a/manifests/sock-shop-base/sock-shop/front-end-dep.yaml
+++ b/manifests/sock-shop-base/sock-shop/front-end-dep.yaml
@@ -4,7 +4,9 @@ kind: Deployment
 metadata:
   name: front-end
   labels:
-    name: front-end
+    app.kubernetes.io/name: front-end
+    app.kubernetes.io/part-of: front-end
+    app.kubernetes.io/component: web
     app: sock-shop
   annotations:
     litmuschaos.io/chaos: "true"
@@ -13,12 +15,16 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      name: front-end
+      app.kubernetes.io/name: front-end
+      app.kubernetes.io/part-of: front-end
+      app.kubernetes.io/component: web
       app: sock-shop
   template:
     metadata:
       labels:
-        name: front-end
+        app.kubernetes.io/name: front-end
+        app.kubernetes.io/part-of: front-end
+        app.kubernetes.io/component: web
         app: sock-shop
     spec:
       containers:

--- a/manifests/sock-shop-base/sock-shop/front-end-svc.yaml
+++ b/manifests/sock-shop-base/sock-shop/front-end-svc.yaml
@@ -4,7 +4,9 @@ kind: Service
 metadata:
   name: front-end
   labels:
-    name: front-end
+    app.kubernetes.io/name: front-end
+    app.kubernetes.io/part-of: front-end
+    app.kubernetes.io/component: web
     app: sock-shop
   namespace: sock-shop
 spec:
@@ -14,5 +16,7 @@ spec:
     targetPort: 8079
     nodePort: 30001
   selector:
-    name: front-end
+    app.kubernetes.io/name: front-end
+    app.kubernetes.io/part-of: front-end
+    app.kubernetes.io/component: web
     app: sock-shop

--- a/manifests/sock-shop-base/sock-shop/orders-db-dep.yaml
+++ b/manifests/sock-shop-base/sock-shop/orders-db-dep.yaml
@@ -4,7 +4,9 @@ kind: Deployment
 metadata:
   name: orders-db
   labels:
-    name: orders-db
+    app.kubernetes.io/name: orders-db
+    app.kubernetes.io/part-of: orders
+    app.kubernetes.io/component: db
     app: sock-shop
   annotations:
     litmuschaos.io/chaos: "true"
@@ -13,12 +15,16 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      name: orders-db
+      app.kubernetes.io/name: orders-db
+      app.kubernetes.io/part-of: orders
+      app.kubernetes.io/component: db
       app: sock-shop
   template:
     metadata:
       labels:
-        name: orders-db
+        app.kubernetes.io/name: orders-db
+        app.kubernetes.io/part-of: orders
+        app.kubernetes.io/component: db
         app: sock-shop
       annotations:
         prometheus.io/scrape: "true"

--- a/manifests/sock-shop-base/sock-shop/orders-db-svc.yaml
+++ b/manifests/sock-shop-base/sock-shop/orders-db-svc.yaml
@@ -4,7 +4,9 @@ kind: Service
 metadata:
   name: orders-db
   labels:
-    name: orders-db
+    app.kubernetes.io/name: orders-db
+    app.kubernetes.io/part-of: orders
+    app.kubernetes.io/component: db
     app: sock-shop
   namespace: sock-shop
 spec:
@@ -13,5 +15,7 @@ spec:
   - port: 27017
     targetPort: 27017
   selector:
-    name: orders-db
+    app.kubernetes.io/name: orders-db
+    app.kubernetes.io/part-of: orders
+    app.kubernetes.io/component: db
     app: sock-shop

--- a/manifests/sock-shop-base/sock-shop/orders-dep.yaml
+++ b/manifests/sock-shop-base/sock-shop/orders-dep.yaml
@@ -4,7 +4,9 @@ kind: Deployment
 metadata:
   name: orders
   labels:
-    name: orders
+    app.kubernetes.io/name: orders
+    app.kubernetes.io/part-of: orders
+    app.kubernetes.io/component: web
     app: sock-shop
   annotations:
     litmuschaos.io/chaos: "true"
@@ -13,12 +15,16 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      name: orders
+      app.kubernetes.io/name: orders
+      app.kubernetes.io/part-of: orders
+      app.kubernetes.io/component: web
       app: sock-shop
   template:
     metadata:
       labels:
-        name: orders
+        app.kubernetes.io/name: orders
+        app.kubernetes.io/part-of: orders
+        app.kubernetes.io/component: web
         app: sock-shop
     spec:
       containers:

--- a/manifests/sock-shop-base/sock-shop/orders-svc.yaml
+++ b/manifests/sock-shop-base/sock-shop/orders-svc.yaml
@@ -4,7 +4,9 @@ kind: Service
 metadata:
   name: orders
   labels:
-    name: orders
+    app.kubernetes.io/name: orders
+    app.kubernetes.io/part-of: orders
+    app.kubernetes.io/component: web
     app: sock-shop
   namespace: sock-shop
 spec:
@@ -13,5 +15,7 @@ spec:
   - port: 80
     targetPort: 80
   selector:
-    name: orders
+    app.kubernetes.io/name: orders
+    app.kubernetes.io/part-of: orders
+    app.kubernetes.io/component: web
     app: sock-shop

--- a/manifests/sock-shop-base/sock-shop/payment-dep.yaml
+++ b/manifests/sock-shop-base/sock-shop/payment-dep.yaml
@@ -4,7 +4,9 @@ kind: Deployment
 metadata:
   name: payment
   labels:
-    name: payment
+    app.kubernetes.io/name: payment
+    app.kubernetes.io/part-of: payment
+    app.kubernetes.io/component: web
     app: sock-shop
   annotations:
     litmuschaos.io/chaos: "true"
@@ -13,12 +15,16 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      name: payment
+      app.kubernetes.io/name: payment
+      app.kubernetes.io/part-of: payment
+      app.kubernetes.io/component: web
       app: sock-shop
   template:
     metadata:
       labels:
-        name: payment
+        app.kubernetes.io/name: payment
+        app.kubernetes.io/part-of: payment
+        app.kubernetes.io/component: web
         app: sock-shop
     spec:
       containers:

--- a/manifests/sock-shop-base/sock-shop/payment-svc.yaml
+++ b/manifests/sock-shop-base/sock-shop/payment-svc.yaml
@@ -4,7 +4,9 @@ kind: Service
 metadata:
   name: payment
   labels:
-    name: payment
+    app.kubernetes.io/name: payment
+    app.kubernetes.io/part-of: payment
+    app.kubernetes.io/component: web
     app: sock-shop
   namespace: sock-shop
 spec:
@@ -13,5 +15,7 @@ spec:
   - port: 80
     targetPort: 80
   selector:
-    name: payment
+    app.kubernetes.io/name: payment
+    app.kubernetes.io/part-of: payment
+    app.kubernetes.io/component: web
     app: sock-shop

--- a/manifests/sock-shop-base/sock-shop/queue-master-dep.yaml
+++ b/manifests/sock-shop-base/sock-shop/queue-master-dep.yaml
@@ -4,7 +4,9 @@ kind: Deployment
 metadata:
   name: queue-master
   labels:
-    name: queue-master
+    app.kubernetes.io/name: queue-master
+    app.kubernetes.io/part-of: queue
+    app.kubernetes.io/component: message-queue
     app: sock-shop
   annotations:
     litmuschaos.io/chaos: "true"
@@ -13,12 +15,16 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      name: queue-master
+      app.kubernetes.io/name: queue-master
+      app.kubernetes.io/part-of: shipping
+      app.kubernetes.io/component: queue-web
       app: sock-shop
   template:
     metadata:
       labels:
-        name: queue-master
+        app.kubernetes.io/name: queue-master
+        app.kubernetes.io/part-of: shipping
+        app.kubernetes.io/component: queue-web
         app: sock-shop
     spec:
       containers:

--- a/manifests/sock-shop-base/sock-shop/queue-master-svc.yaml
+++ b/manifests/sock-shop-base/sock-shop/queue-master-svc.yaml
@@ -4,7 +4,9 @@ kind: Service
 metadata:
   name: queue-master
   labels:
-    name: queue-master
+    app.kubernetes.io/name: queue-master
+    app.kubernetes.io/part-of: shipping
+    app.kubernetes.io/component: queue-web
     app: sock-shop
   annotations:
     prometheus.io/path: "/prometheus"
@@ -15,5 +17,7 @@ spec:
   - port: 80
     targetPort: 80
   selector:
-    name: queue-master
+    app.kubernetes.io/name: queue-master
+    app.kubernetes.io/part-of: shipping
+    app.kubernetes.io/component: queue-web
     app: sock-shop

--- a/manifests/sock-shop-base/sock-shop/rabbitmq-dep.yaml
+++ b/manifests/sock-shop-base/sock-shop/rabbitmq-dep.yaml
@@ -4,7 +4,9 @@ kind: Deployment
 metadata:
   name: rabbitmq
   labels:
-    name: rabbitmq
+    app.kubernetes.io/name: rabbitmq
+    app.kubernetes.io/part-of: shipping
+    app.kubernetes.io/component: queue-db
     app: sock-shop
   annotations:
     litmuschaos.io/chaos: "true"
@@ -13,12 +15,16 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      name: rabbitmq
+      app.kubernetes.io/name: rabbitmq
+      app.kubernetes.io/part-of: shipping
+      app.kubernetes.io/component: queue-db
       app: sock-shop
   template:
     metadata:
       labels:
-        name: rabbitmq
+        app.kubernetes.io/name: rabbitmq
+        app.kubernetes.io/part-of: shipping
+        app.kubernetes.io/component: queue-db
         app: sock-shop
       annotations:
         prometheus.io/scrape: "false"

--- a/manifests/sock-shop-base/sock-shop/rabbitmq-svc.yaml
+++ b/manifests/sock-shop-base/sock-shop/rabbitmq-svc.yaml
@@ -4,7 +4,9 @@ kind: Service
 metadata:
   name: rabbitmq
   labels:
-    name: rabbitmq
+    app.kubernetes.io/name: rabbitmq
+    app.kubernetes.io/part-of: shipping
+    app.kubernetes.io/component: queue-db
     app: sock-shop
   namespace: sock-shop
 spec:
@@ -18,5 +20,7 @@ spec:
     targetPort: exporter
     protocol: TCP
   selector:
-    name: rabbitmq
+    app.kubernetes.io/name: rabbitmq
+    app.kubernetes.io/part-of: shipping
+    app.kubernetes.io/component: queue-db
     app: sock-shop

--- a/manifests/sock-shop-base/sock-shop/session-db-dep.yaml
+++ b/manifests/sock-shop-base/sock-shop/session-db-dep.yaml
@@ -4,7 +4,9 @@ kind: Deployment
 metadata:
   name: session-db
   labels:
-    name: session-db
+    app.kubernetes.io/name: session-db
+    app.kubernetes.io/part-of: front-end
+    app.kubernetes.io/component: db
     app: sock-shop
   annotations:
     litmuschaos.io/chaos: "true"
@@ -13,12 +15,16 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      name: session-db
+      app.kubernetes.io/name: session-db
+      app.kubernetes.io/part-of: front-end
+      app.kubernetes.io/component: db
       app: sock-shop
   template:
     metadata:
       labels:
-        name: session-db
+        app.kubernetes.io/name: session-db
+        app.kubernetes.io/part-of: front-end
+        app.kubernetes.io/component: db
         app: sock-shop
       annotations:
         prometheus.io.scrape: "true"

--- a/manifests/sock-shop-base/sock-shop/session-db-svc.yaml
+++ b/manifests/sock-shop-base/sock-shop/session-db-svc.yaml
@@ -4,7 +4,9 @@ kind: Service
 metadata:
   name: session-db
   labels:
-    name: session-db
+    app.kubernetes.io/name: session-db
+    app.kubernetes.io/part-of: front-end
+    app.kubernetes.io/component: db
     app: sock-shop
   namespace: sock-shop
 spec:
@@ -13,5 +15,7 @@ spec:
   - port: 6379
     targetPort: 6379
   selector:
-    name: session-db
+    app.kubernetes.io/name: session-db
+    app.kubernetes.io/part-of: front-end
+    app.kubernetes.io/component: db
     app: sock-shop

--- a/manifests/sock-shop-base/sock-shop/shipping-dep.yaml
+++ b/manifests/sock-shop-base/sock-shop/shipping-dep.yaml
@@ -4,7 +4,9 @@ kind: Deployment
 metadata:
   name: shipping
   labels:
-    name: shipping
+    app.kubernetes.io/name: shipping
+    app.kubernetes.io/part-of: shipping
+    app.kubernetes.io/component: web
     app: sock-shop
   annotations:
     litmuschaos.io/chaos: "true"
@@ -13,12 +15,16 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      name: shipping
+      app.kubernetes.io/name: shipping
+      app.kubernetes.io/part-of: shipping
+      app.kubernetes.io/component: web
       app: sock-shop
   template:
     metadata:
       labels:
-        name: shipping
+        app.kubernetes.io/name: shipping
+        app.kubernetes.io/part-of: shipping
+        app.kubernetes.io/component: web
         app: sock-shop
     spec:
       containers:

--- a/manifests/sock-shop-base/sock-shop/shipping-svc.yaml
+++ b/manifests/sock-shop-base/sock-shop/shipping-svc.yaml
@@ -4,7 +4,9 @@ kind: Service
 metadata:
   name: shipping
   labels:
-    name: shipping
+    app.kubernetes.io/name: shipping
+    app.kubernetes.io/part-of: shipping
+    app.kubernetes.io/component: web
     app: sock-shop
   namespace: sock-shop
 spec:
@@ -13,5 +15,7 @@ spec:
   - port: 80
     targetPort: 80
   selector:
-    name: shipping
+    app.kubernetes.io/name: shipping
+    app.kubernetes.io/part-of: shipping
+    app.kubernetes.io/component: web
     app: sock-shop

--- a/manifests/sock-shop-base/sock-shop/user-db-dep.yaml
+++ b/manifests/sock-shop-base/sock-shop/user-db-dep.yaml
@@ -4,7 +4,9 @@ kind: Deployment
 metadata:
   name: user-db
   labels:
-    name: user-db
+    app.kubernetes.io/name: user-db
+    app.kubernetes.io/part-of: user
+    app.kubernetes.io/component: db
     app: sock-shop
   annotations:
     litmuschaos.io/chaos: "true"
@@ -13,12 +15,16 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      name: user-db
+      app.kubernetes.io/name: user-db
+      app.kubernetes.io/part-of: user
+      app.kubernetes.io/component: db
       app: sock-shop
   template:
     metadata:
       labels:
-        name: user-db
+        app.kubernetes.io/name: user-db
+        app.kubernetes.io/part-of: user
+        app.kubernetes.io/component: db
         app: sock-shop
       annotations:
         prometheus.io/scrape: "true"

--- a/manifests/sock-shop-base/sock-shop/user-db-svc.yaml
+++ b/manifests/sock-shop-base/sock-shop/user-db-svc.yaml
@@ -4,7 +4,9 @@ kind: Service
 metadata:
   name: user-db
   labels:
-    name: user-db
+    app.kubernetes.io/name: user-db
+    app.kubernetes.io/part-of: user
+    app.kubernetes.io/component: db
     app: sock-shop
   namespace: sock-shop
 spec:
@@ -13,5 +15,7 @@ spec:
   - port: 27017
     targetPort: 27017
   selector:
-    name: user-db
+    app.kubernetes.io/name: user-db
+    app.kubernetes.io/part-of: user
+    app.kubernetes.io/component: db
     app: sock-shop

--- a/manifests/sock-shop-base/sock-shop/user-dep.yaml
+++ b/manifests/sock-shop-base/sock-shop/user-dep.yaml
@@ -4,7 +4,9 @@ kind: Deployment
 metadata:
   name: user
   labels:
-    name: user
+    app.kubernetes.io/name: user
+    app.kubernetes.io/part-of: user
+    app.kubernetes.io/component: web
     app: sock-shop
   annotations:
     litmuschaos.io/chaos: "true"
@@ -13,12 +15,16 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      name: user
+      app.kubernetes.io/name: user
+      app.kubernetes.io/part-of: user
+      app.kubernetes.io/component: web
       app: sock-shop
   template:
     metadata:
       labels:
-        name: user
+        app.kubernetes.io/name: user
+        app.kubernetes.io/part-of: user
+        app.kubernetes.io/component: web
         app: sock-shop
     spec:
       containers:

--- a/manifests/sock-shop-base/sock-shop/user-svc.yaml
+++ b/manifests/sock-shop-base/sock-shop/user-svc.yaml
@@ -4,7 +4,9 @@ kind: Service
 metadata:
   name: user
   labels:
-    name: user
+    app.kubernetes.io/name: user
+    app.kubernetes.io/part-of: user
+    app.kubernetes.io/component: web
     app: sock-shop
   namespace: sock-shop
 spec:
@@ -13,5 +15,7 @@ spec:
   - port: 80
     targetPort: 80
   selector:
-    name: user
+    app.kubernetes.io/name: user
+    app.kubernetes.io/part-of: user
+    app.kubernetes.io/component: web
     app: sock-shop

--- a/manifests/train-ticket-base/app/ts-part1.yaml
+++ b/manifests/train-ticket-base/app/ts-part1.yaml
@@ -2,15 +2,23 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ts-user-mongo
+  labels:
+    app.kubernetes.io/name: ts-user-mongo
+    app.kubernetes.io/part-of: ts-user
+    app.kubernetes.io/component: db
 spec:
   selector:
     matchLabels:
-      app: ts-user-mongo
+      app.kubernetes.io/name: ts-user-mongo
+      app.kubernetes.io/part-of: ts-user
+      app.kubernetes.io/component: db
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-user-mongo
+        app.kubernetes.io/name: ts-user-mongo
+        app.kubernetes.io/part-of: ts-user
+        app.kubernetes.io/component: db
     spec:
       containers:
       - name: ts-user-mongo
@@ -28,15 +36,23 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ts-auth-mongo
+  labels:
+    app.kubernetes.io/name: ts-auth-mongo
+    app.kubernetes.io/part-of: ts-auth
+    app.kubernetes.io/component: db
 spec:
   selector:
     matchLabels:
-      app: ts-auth-mongo
+      app.kubernetes.io/name: ts-auth-mongo
+      app.kubernetes.io/part-of: ts-auth
+      app.kubernetes.io/component: db
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-auth-mongo
+        app.kubernetes.io/name: ts-auth-mongo
+        app.kubernetes.io/part-of: ts-auth
+        app.kubernetes.io/component: db
     spec:
       containers:
       - name: ts-auth-mongo
@@ -54,15 +70,23 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ts-route-mongo
+  labels:
+    app.kubernetes.io/name: ts-route-mongo
+    app.kubernetes.io/part-of: ts-route
+    app.kubernetes.io/component: db
 spec:
   selector:
     matchLabels:
-      app: ts-route-mongo
+      app.kubernetes.io/name: ts-route-mongo
+      app.kubernetes.io/part-of: ts-route
+      app.kubernetes.io/component: db
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-route-mongo
+        app.kubernetes.io/name: ts-route-mongo
+        app.kubernetes.io/part-of: ts-route
+        app.kubernetes.io/component: db
     spec:
       containers:
       - name: ts-route-mongo
@@ -81,15 +105,23 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ts-contacts-mongo
+  labels:
+    app.kubernetes.io/name: ts-contacts-mongo
+    app.kubernetes.io/part-of: ts-contacts
+    app.kubernetes.io/component: db
 spec:
   selector:
     matchLabels:
-      app: ts-contacts-mongo
+      app.kubernetes.io/name: ts-contacts-mongo
+      app.kubernetes.io/part-of: ts-contacts
+      app.kubernetes.io/component: db
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-contacts-mongo
+        app.kubernetes.io/name: ts-contacts-mongo
+        app.kubernetes.io/part-of: ts-contacts
+        app.kubernetes.io/component: db
     spec:
       containers:
       - name: ts-contacts-mongo
@@ -108,15 +140,23 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ts-order-mongo
+  labels:
+    app.kubernetes.io/name: ts-order-mongo
+    app.kubernetes.io/part-of: ts-order
+    app.kubernetes.io/component: db
 spec:
   selector:
     matchLabels:
-      app: ts-order-mongo
+      app.kubernetes.io/name: ts-order-mongo
+      app.kubernetes.io/part-of: ts-order
+      app.kubernetes.io/component: db
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-order-mongo
+        app.kubernetes.io/name: ts-order-mongo
+        app.kubernetes.io/part-of: ts-order
+        app.kubernetes.io/component: db
     spec:
       containers:
       - name: ts-order-mongo
@@ -135,15 +175,23 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ts-order-other-mongo
+  labels:
+    app.kubernetes.io/name: ts-order-other-mongo
+    app.kubernetes.io/part-of: ts-order-other
+    app.kubernetes.io/component: db
 spec:
   selector:
     matchLabels:
-      app: ts-order-other-mongo
+      app.kubernetes.io/name: ts-order-other-mongo
+      app.kubernetes.io/part-of: ts-order-other
+      app.kubernetes.io/component: db
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-order-other-mongo
+        app.kubernetes.io/name: ts-order-other-mongo
+        app.kubernetes.io/part-of: ts-order-other
+        app.kubernetes.io/component: db
     spec:
       containers:
       - name: ts-order-other-mongo
@@ -162,15 +210,23 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ts-config-mongo
+  labels:
+    app.kubernetes.io/name: ts-config-mongo
+    app.kubernetes.io/part-of: ts-config
+    app.kubernetes.io/component: db
 spec:
   selector:
     matchLabels:
-      app: ts-config-mongo
+      app.kubernetes.io/name: ts-config-mongo
+      app.kubernetes.io/part-of: ts-config
+      app.kubernetes.io/component: db
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-config-mongo
+        app.kubernetes.io/name: ts-config-mongo
+        app.kubernetes.io/part-of: ts-config
+        app.kubernetes.io/component: db
     spec:
       containers:
       - name: ts-config-mongo
@@ -189,15 +245,23 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ts-station-mongo
+  labels:
+    app.kubernetes.io/name: ts-station-mongo
+    app.kubernetes.io/part-of: ts-station
+    app.kubernetes.io/component: db
 spec:
   selector:
     matchLabels:
-      app: ts-station-mongo
+      app.kubernetes.io/name: ts-station-mongo
+      app.kubernetes.io/part-of: ts-station
+      app.kubernetes.io/component: db
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-station-mongo
+        app.kubernetes.io/name: ts-station-mongo
+        app.kubernetes.io/part-of: ts-station
+        app.kubernetes.io/component: db
     spec:
       containers:
       - name: ts-station-mongo
@@ -216,15 +280,23 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ts-train-mongo
+  labels:
+    app.kubernetes.io/name: ts-train-mongo
+    app.kubernetes.io/part-of: ts-train
+    app.kubernetes.io/component: db
 spec:
   selector:
     matchLabels:
-      app: ts-train-mongo
+      app.kubernetes.io/name: ts-train-mongo
+      app.kubernetes.io/part-of: ts-train
+      app.kubernetes.io/component: db
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-train-mongo
+        app.kubernetes.io/name: ts-train-mongo
+        app.kubernetes.io/part-of: ts-train
+        app.kubernetes.io/component: db
     spec:
       containers:
       - name: ts-train-mongo
@@ -243,15 +315,23 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ts-travel-mongo
+  labels:
+    app.kubernetes.io/name: ts-travel-mongo
+    app.kubernetes.io/part-of: ts-travel
+    app.kubernetes.io/component: db
 spec:
   selector:
     matchLabels:
-      app: ts-travel-mongo
+      app.kubernetes.io/name: ts-travel-mongo
+      app.kubernetes.io/part-of: ts-travel
+      app.kubernetes.io/component: db
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-travel-mongo
+        app.kubernetes.io/name: ts-travel-mongo
+        app.kubernetes.io/part-of: ts-travel
+        app.kubernetes.io/component: db
     spec:
       containers:
       - name: ts-travel-mongo
@@ -270,15 +350,23 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ts-travel2-mongo
+  labels:
+    app.kubernetes.io/name: ts-travel2-mongo
+    app.kubernetes.io/part-of: ts-travel2
+    app.kubernetes.io/component: db
 spec:
   selector:
     matchLabels:
-      app: ts-travel2-mongo
+      app.kubernetes.io/name: ts-travel2-mongo
+      app.kubernetes.io/part-of: ts-travel
+      app.kubernetes.io/component: db
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-travel2-mongo
+        app.kubernetes.io/name: ts-travel2-mongo
+        app.kubernetes.io/part-of: ts-travel
+        app.kubernetes.io/component: db
     spec:
       containers:
       - name: ts-travel2-mongo
@@ -297,15 +385,23 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ts-price-mongo
+  labels:
+    app.kubernetes.io/name: ts-price-mongo
+    app.kubernetes.io/part-of: ts-price
+    app.kubernetes.io/component: db
 spec:
   selector:
     matchLabels:
-      app: ts-price-mongo
+      app.kubernetes.io/name: ts-price-mongo
+      app.kubernetes.io/part-of: ts-price
+      app.kubernetes.io/component: db
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-price-mongo
+        app.kubernetes.io/name: ts-price-mongo
+        app.kubernetes.io/part-of: ts-price
+        app.kubernetes.io/component: db
     spec:
       containers:
       - name: ts-price-mongo
@@ -324,15 +420,23 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ts-security-mongo
+  labels:
+    app.kubernetes.io/name: ts-security-mongo
+    app.kubernetes.io/part-of: ts-security
+    app.kubernetes.io/component: db
 spec:
   selector:
     matchLabels:
-      app: ts-security-mongo
+      app.kubernetes.io/name: ts-security-mongo
+      app.kubernetes.io/part-of: ts-security
+      app.kubernetes.io/component: db
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-security-mongo
+        app.kubernetes.io/name: ts-security-mongo
+        app.kubernetes.io/part-of: ts-security
+        app.kubernetes.io/component: db
     spec:
       containers:
       - name: ts-security-mongo
@@ -351,15 +455,23 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ts-inside-payment-mongo
+  labels:
+    app.kubernetes.io/name: ts-inside-payment-mongo
+    app.kubernetes.io/part-of: ts-inside-payment
+    app.kubernetes.io/component: db
 spec:
   selector:
     matchLabels:
-      app: ts-inside-payment-mongo
+      app.kubernetes.io/name: ts-inside-payment-mongo
+      app.kubernetes.io/part-of: ts-inside-payment
+      app.kubernetes.io/component: db
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-inside-payment-mongo
+        app.kubernetes.io/name: ts-inside-payment-mongo
+        app.kubernetes.io/part-of: ts-inside-payment
+        app.kubernetes.io/component: db
     spec:
       containers:
       - name: ts-inside-payment-mongo
@@ -378,15 +490,23 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ts-payment-mongo
+  labels:
+    app.kubernetes.io/name: ts-payment-mongo
+    app.kubernetes.io/part-of: ts-payment
+    app.kubernetes.io/component: db
 spec:
   selector:
     matchLabels:
-      app: ts-payment-mongo
+      app.kubernetes.io/name: ts-payment-mongo
+      app.kubernetes.io/part-of: ts-payment
+      app.kubernetes.io/component: db
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-payment-mongo
+        app.kubernetes.io/name: ts-payment-mongo
+        app.kubernetes.io/part-of: ts-payment
+        app.kubernetes.io/component: db
     spec:
       containers:
       - name: ts-payment-mongo
@@ -405,15 +525,23 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ts-assurance-mongo
+  labels:
+    app.kubernetes.io/name: ts-assurance-mongo
+    app.kubernetes.io/part-of: ts-assurance
+    app.kubernetes.io/component: db
 spec:
   selector:
     matchLabels:
-      app: ts-assurance-mongo
+      app.kubernetes.io/name: ts-assurance-mongo
+      app.kubernetes.io/part-of: ts-assurance
+      app.kubernetes.io/component: db
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-assurance-mongo
+        app.kubernetes.io/name: ts-assurance-mongo
+        app.kubernetes.io/part-of: ts-assurance
+        app.kubernetes.io/component: db
     spec:
       containers:
       - name: ts-assurance-mongo
@@ -432,15 +560,23 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ts-ticket-office-mongo
+  labels:
+    app.kubernetes.io/name: ts-ticket-office-mongo
+    app.kubernetes.io/part-of: ts-ticket-office
+    app.kubernetes.io/component: db
 spec:
   selector:
     matchLabels:
-      app: ts-ticket-office-mongo
+      app.kubernetes.io/name: ts-ticket-office-mongo
+      app.kubernetes.io/part-of: ts-ticket-office
+      app.kubernetes.io/component: db
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-ticket-office-mongo
+        app.kubernetes.io/name: ts-ticket-office-mongo
+        app.kubernetes.io/part-of: ts-ticket-office
+        app.kubernetes.io/component: db
     spec:
       containers:
       - name: ts-ticket-office-mongo
@@ -460,15 +596,23 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ts-voucher-mysql
+  labels:
+    app.kubernetes.io/name: ts-voucher-mysql
+    app.kubernetes.io/part-of: ts-voucher
+    app.kubernetes.io/component: db
 spec:
   selector:
     matchLabels:
-      app: ts-voucher-mysql
+      app.kubernetes.io/name: ts-voucher-mysql
+      app.kubernetes.io/part-of: ts-voucher
+      app.kubernetes.io/component: db
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-voucher-mysql
+        app.kubernetes.io/name: ts-voucher-mysql
+        app.kubernetes.io/part-of: ts-voucher
+        app.kubernetes.io/component: db
     spec:
       containers:
       - name: ts-voucher-mysql
@@ -491,15 +635,23 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ts-food-map-mongo
+  labels:
+    app.kubernetes.io/name: ts-food-map-mongo
+    app.kubernetes.io/part-of: ts-food-map
+    app.kubernetes.io/component: db
 spec:
   selector:
     matchLabels:
-      app: ts-food-map-mongo
+      app.kubernetes.io/name: ts-food-map-mongo
+      app.kubernetes.io/part-of: ts-food-map
+      app.kubernetes.io/component: db
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-food-map-mongo
+        app.kubernetes.io/name: ts-food-map-mongo
+        app.kubernetes.io/part-of: ts-food-map
+        app.kubernetes.io/component: db
     spec:
       containers:
       - name: ts-food-map-mongo
@@ -518,15 +670,23 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ts-consign-mongo
+  labels:
+    app.kubernetes.io/name: ts-consign-mongo
+    app.kubernetes.io/part-of: ts-consign
+    app.kubernetes.io/component: db
 spec:
   selector:
     matchLabels:
-      app: ts-consign-mongo
+      app.kubernetes.io/name: ts-consign-mongo
+      app.kubernetes.io/part-of: ts-consign
+      app.kubernetes.io/component: db
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-consign-mongo
+        app.kubernetes.io/name: ts-consign-mongo
+        app.kubernetes.io/part-of: ts-consign
+        app.kubernetes.io/component: db
     spec:
       containers:
       - name: ts-consign-mongo
@@ -545,15 +705,23 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ts-consign-price-mongo
+  labels:
+    app.kubernetes.io/name: ts-consign-price-mongo
+    app.kubernetes.io/part-of: ts-consign-price
+    app.kubernetes.io/component: db
 spec:
   selector:
     matchLabels:
-      app: ts-consign-price-mongo
+      app.kubernetes.io/name: ts-consign-price-mongo
+      app.kubernetes.io/part-of: ts-consign-price
+      app.kubernetes.io/component: db
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-consign-price-mongo
+        app.kubernetes.io/name: ts-consign-price-mongo
+        app.kubernetes.io/part-of: ts-consign-price
+        app.kubernetes.io/component: db
     spec:
       containers:
       - name: ts-consign-price-mongo
@@ -572,15 +740,23 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ts-food-mongo
+  labels:
+    app.kubernetes.io/name: ts-food-mongo
+    app.kubernetes.io/part-of: ts-food
+    app.kubernetes.io/component: db
 spec:
   selector:
     matchLabels:
-      app: ts-food-mongo
+      app.kubernetes.io/name: ts-food-mongo
+      app.kubernetes.io/part-of: ts-food
+      app.kubernetes.io/component: db
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-food-mongo
+        app.kubernetes.io/name: ts-food-mongo
+        app.kubernetes.io/part-of: ts-food
+        app.kubernetes.io/component: db
     spec:
       containers:
       - name: ts-food-mongo
@@ -598,33 +774,51 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-user-mongo
+  labels:
+    app.kubernetes.io/name: ts-food-mongo
+    app.kubernetes.io/part-of: ts-food
+    app.kubernetes.io/component: db
 spec:
   ports:
     - port: 27017
   selector:
-    app: ts-user-mongo
+    app.kubernetes.io/name: ts-food-mongo
+    app.kubernetes.io/part-of: ts-food
+    app.kubernetes.io/component: db
 
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: ts-auth-mongo
+  labels:
+    app.kubernetes.io/name: ts-auth-mongo
+    app.kubernetes.io/part-of: ts-auth
+    app.kubernetes.io/component: db
 spec:
   ports:
     - port: 27017
   selector:
-    app: ts-auth-mongo
+    app.kubernetes.io/name: ts-auth-mongo
+    app.kubernetes.io/part-of: ts-auth
+    app.kubernetes.io/component: db
 ---
 
 apiVersion: v1
 kind: Service
 metadata:
   name: ts-route-mongo
+  labels:
+    app.kubernetes.io/name: ts-route-mongo
+    app.kubernetes.io/part-of: ts-route
+    app.kubernetes.io/component: db
 spec:
   ports:
     - port: 27017
   selector:
-    app: ts-route-mongo
+    app.kubernetes.io/name: ts-route-mongo
+    app.kubernetes.io/part-of: ts-route
+    app.kubernetes.io/component: db
 
 ---
 
@@ -632,11 +826,17 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-contacts-mongo
+  labels:
+    app.kubernetes.io/name: ts-contacts-mongo
+    app.kubernetes.io/part-of: ts-contacts
+    app.kubernetes.io/component: db
 spec:
   ports:
     - port: 27017
   selector:
-    app: ts-contacts-mongo
+    app.kubernetes.io/name: ts-contacts-mongo
+    app.kubernetes.io/part-of: ts-contacts
+    app.kubernetes.io/component: db
 
 ---
 
@@ -644,11 +844,17 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-order-mongo
+  labels:
+    app.kubernetes.io/name: ts-order-mongo
+    app.kubernetes.io/part-of: ts-order
+    app.kubernetes.io/component: db
 spec:
   ports:
     - port: 27017
   selector:
-    app: ts-order-mongo
+    app.kubernetes.io/name: ts-order-mongo
+    app.kubernetes.io/part-of: ts-order
+    app.kubernetes.io/component: db
 
 ---
 
@@ -656,11 +862,17 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-order-other-mongo
+  labels:
+    app.kubernetes.io/name: ts-order-other-mongo
+    app.kubernetes.io/part-of: ts-order-other
+    app.kubernetes.io/component: db
 spec:
   ports:
     - port: 27017
   selector:
-    app: ts-order-other-mongo
+    app.kubernetes.io/name: ts-order-other-mongo
+    app.kubernetes.io/part-of: ts-order-other
+    app.kubernetes.io/component: db
 
 ---
 
@@ -668,11 +880,17 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-config-mongo
+  labels:
+    app.kubernetes.io/name: ts-config-mongo
+    app.kubernetes.io/part-of: ts-config
+    app.kubernetes.io/component: db
 spec:
   ports:
     - port: 27017
   selector:
-    app: ts-config-mongo
+    app.kubernetes.io/name: ts-config-mongo
+    app.kubernetes.io/part-of: ts-config
+    app.kubernetes.io/component: db
 
 ---
 
@@ -680,11 +898,17 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-station-mongo
+  labels:
+    app.kubernetes.io/name: ts-station-mongo
+    app.kubernetes.io/part-of: ts-station
+    app.kubernetes.io/component: db
 spec:
   ports:
     - port: 27017
   selector:
-    app: ts-station-mongo
+    app.kubernetes.io/name: ts-station-mongo
+    app.kubernetes.io/part-of: ts-station
+    app.kubernetes.io/component: db
 
 ---
 
@@ -692,11 +916,17 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-train-mongo
+  labels:
+    app.kubernetes.io/name: ts-train-mongo
+    app.kubernetes.io/part-of: ts-train
+    app.kubernetes.io/component: db
 spec:
   ports:
     - port: 27017
   selector:
-    app: ts-train-mongo
+    app.kubernetes.io/name: ts-train-mongo
+    app.kubernetes.io/part-of: ts-train
+    app.kubernetes.io/component: db
 
 ---
 
@@ -704,11 +934,17 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-travel-mongo
+  labels:
+    app.kubernetes.io/name: ts-travel-mongo
+    app.kubernetes.io/part-of: ts-travel
+    app.kubernetes.io/component: db
 spec:
   ports:
     - port: 27017
   selector:
-    app: ts-travel-mongo
+    app.kubernetes.io/name: ts-travel-mongo
+    app.kubernetes.io/part-of: ts-travel
+    app.kubernetes.io/component: db
 
 ---
 
@@ -716,11 +952,17 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-travel2-mongo
+  labels:
+    app.kubernetes.io/name: ts-travel2-mongo
+    app.kubernetes.io/part-of: ts-travel2
+    app.kubernetes.io/component: db
 spec:
   ports:
     - port: 27017
   selector:
-    app: ts-travel2-mongo
+    app.kubernetes.io/name: ts-travel2-mongo
+    app.kubernetes.io/part-of: ts-travel2
+    app.kubernetes.io/component: db
 
 ---
 
@@ -728,11 +970,17 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-price-mongo
+  labels:
+    app.kubernetes.io/name: ts-price-mongo
+    app.kubernetes.io/part-of: ts-price
+    app.kubernetes.io/component: db
 spec:
   ports:
     - port: 27017
   selector:
-    app: ts-price-mongo
+    app.kubernetes.io/name: ts-price-mongo
+    app.kubernetes.io/part-of: ts-price
+    app.kubernetes.io/component: db
 
 ---
 
@@ -740,11 +988,17 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-security-mongo
+  labels:
+    app.kubernetes.io/name: ts-security-mongo
+    app.kubernetes.io/part-of: ts-security
+    app.kubernetes.io/component: db
 spec:
   ports:
     - port: 27017
   selector:
-    app: ts-security-mongo
+    app.kubernetes.io/name: ts-security-mongo
+    app.kubernetes.io/part-of: ts-security
+    app.kubernetes.io/component: db
 
 ---
 
@@ -752,11 +1006,17 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-inside-payment-mongo
+  labels:
+    app.kubernetes.io/name: ts-inside-payment-mongo
+    app.kubernetes.io/part-of: ts-inside-payment
+    app.kubernetes.io/component: db
 spec:
   ports:
     - port: 27017
   selector:
-    app: ts-inside-payment-mongo
+    app.kubernetes.io/name: ts-inside-payment-mongo
+    app.kubernetes.io/part-of: ts-inside-payment
+    app.kubernetes.io/component: db
 
 ---
 
@@ -764,11 +1024,17 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-payment-mongo
+  labels:
+    app.kubernetes.io/name: ts-payment-mongo
+    app.kubernetes.io/part-of: ts-payment
+    app.kubernetes.io/component: db
 spec:
   ports:
     - port: 27017
   selector:
-    app: ts-payment-mongo
+    app.kubernetes.io/name: ts-payment-mongo
+    app.kubernetes.io/part-of: ts-payment
+    app.kubernetes.io/component: db
 
 ---
 
@@ -776,11 +1042,17 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-assurance-mongo
+  labels:
+    app.kubernetes.io/name: ts-assurance-mongo
+    app.kubernetes.io/part-of: ts-assurance
+    app.kubernetes.io/component: db
 spec:
   ports:
     - port: 27017
   selector:
-    app: ts-assurance-mongo
+    app.kubernetes.io/name: ts-assurance-mongo
+    app.kubernetes.io/part-of: ts-assurance
+    app.kubernetes.io/component: db
 
 ---
 
@@ -788,11 +1060,17 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-ticket-office-mongo
+  labels:
+    app.kubernetes.io/name: ts-ticket-office-mongo
+    app.kubernetes.io/part-of: ts-ticket-office
+    app.kubernetes.io/component: db
 spec:
   ports:
     - port: 27017
   selector:
-    app: ts-ticket-office-mongo
+    app.kubernetes.io/name: ts-ticket-office-mongo
+    app.kubernetes.io/part-of: ts-ticket-office
+    app.kubernetes.io/component: db
 
 ---
 
@@ -800,11 +1078,17 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-voucher-mysql
+  labels:
+    app.kubernetes.io/name: ts-voucher-mysql
+    app.kubernetes.io/part-of: ts-voucher
+    app.kubernetes.io/component: db
 spec:
   ports:
     - port: 3306
   selector:
-    app: ts-voucher-mysql
+    app.kubernetes.io/name: ts-voucher-mysql
+    app.kubernetes.io/part-of: ts-voucher
+    app.kubernetes.io/component: db
 
 ---
 
@@ -812,11 +1096,17 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-food-map-mongo
+  labels:
+    app.kubernetes.io/name: ts-food-map-mongo
+    app.kubernetes.io/part-of: ts-food-map
+    app.kubernetes.io/component: db
 spec:
   ports:
     - port: 27017
   selector:
-    app: ts-food-map-mongo
+    app.kubernetes.io/name: ts-food-map-mongo
+    app.kubernetes.io/part-of: ts-food-map
+    app.kubernetes.io/component: db
 
 ---
 
@@ -824,11 +1114,17 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-consign-mongo
+  labels:
+    app.kubernetes.io/name: ts-consign-mongo
+    app.kubernetes.io/part-of: ts-consign
+    app.kubernetes.io/component: db
 spec:
   ports:
     - port: 27017
   selector:
-    app: ts-consign-mongo
+    app.kubernetes.io/name: ts-consign-mongo
+    app.kubernetes.io/part-of: ts-consign
+    app.kubernetes.io/component: db
 
 ---
 
@@ -836,11 +1132,17 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-consign-price-mongo
+  labels:
+    app.kubernetes.io/name: ts-consign-price-mongo
+    app.kubernetes.io/part-of: ts-consign-price
+    app.kubernetes.io/component: db
 spec:
   ports:
     - port: 27017
   selector:
-    app: ts-consign-price-mongo
+    app.kubernetes.io/name: ts-consign-price-mongo
+    app.kubernetes.io/part-of: ts-consign-price
+    app.kubernetes.io/component: db
 
 ---
 
@@ -848,8 +1150,14 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-food-mongo
+  labels:
+    app.kubernetes.io/name: ts-food-mongo
+    app.kubernetes.io/part-of: ts-food
+    app.kubernetes.io/component: db
 spec:
   ports:
     - port: 27017
   selector:
-    app: ts-food-mongo
+    app.kubernetes.io/name: ts-food-mongo
+    app.kubernetes.io/part-of: ts-food
+    app.kubernetes.io/component: db

--- a/manifests/train-ticket-base/app/ts-part1.yaml
+++ b/manifests/train-ticket-base/app/ts-part1.yaml
@@ -358,14 +358,14 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: ts-travel2-mongo
-      app.kubernetes.io/part-of: ts-travel
+      app.kubernetes.io/part-of: ts-travel2
       app.kubernetes.io/component: db
   replicas: 1
   template:
     metadata:
       labels:
         app.kubernetes.io/name: ts-travel2-mongo
-        app.kubernetes.io/part-of: ts-travel
+        app.kubernetes.io/part-of: ts-travel2
         app.kubernetes.io/component: db
     spec:
       containers:

--- a/manifests/train-ticket-base/app/ts-part2.yaml
+++ b/manifests/train-ticket-base/app/ts-part2.yaml
@@ -1887,11 +1887,11 @@ spec:
         - containerPort: 16346
         resources:
           requests:
-            cpu: 50m
-            memory: 160Mi
-          limits:
             cpu: 200m
             memory: 500Mi
+          limits:
+            cpu: 200m
+            memory: 750Mi
         readinessProbe:
           tcpSocket:
             port: 16346

--- a/manifests/train-ticket-base/app/ts-part2.yaml
+++ b/manifests/train-ticket-base/app/ts-part2.yaml
@@ -41,7 +41,7 @@ spec:
             cpu: 50m
             memory: 100Mi
           limits:
-            cpu: 200m
+            cpu: 100m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -95,7 +95,7 @@ spec:
             cpu: 50m
             memory: 160Mi
           limits:
-            cpu: 200m
+            cpu: 100m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -148,7 +148,7 @@ spec:
             cpu: 50m
             memory: 160Mi
           limits:
-            cpu: 200m
+            cpu: 100m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -201,7 +201,7 @@ spec:
             cpu: 50m
             memory: 160Mi
           limits:
-            cpu: 200m
+            cpu: 100m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -254,7 +254,7 @@ spec:
             cpu: 50m
             memory: 160Mi
           limits:
-            cpu: 200m
+            cpu: 150m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -307,8 +307,8 @@ spec:
             cpu: 50m
             memory: 160Mi
           limits:
-            cpu: 200m
-            memory: 500Mi
+            cpu: 100m
+            memory: 400Mi
         readinessProbe:
           tcpSocket:
             port: 18888
@@ -413,7 +413,7 @@ spec:
             cpu: 50m
             memory: 160Mi
           limits:
-            cpu: 200m
+            cpu: 100m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -466,7 +466,7 @@ spec:
             cpu: 50m
             memory: 160Mi
           limits:
-            cpu: 200m
+            cpu: 100m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -519,7 +519,7 @@ spec:
             cpu: 50m
             memory: 160Mi
           limits:
-            cpu: 200m
+            cpu: 100m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -572,7 +572,7 @@ spec:
             cpu: 50m
             memory: 160Mi
           limits:
-            cpu: 200m
+            cpu: 100m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -625,7 +625,7 @@ spec:
             cpu: 50m
             memory: 160Mi
           limits:
-            cpu: 200m
+            cpu: 100m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -678,7 +678,7 @@ spec:
             cpu: 50m
             memory: 160Mi
           limits:
-            cpu: 200m
+            cpu: 100m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -731,7 +731,7 @@ spec:
             cpu: 50m
             memory: 160Mi
           limits:
-            cpu: 200m
+            cpu: 100m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -837,7 +837,7 @@ spec:
             cpu: 50m
             memory: 160Mi
           limits:
-            cpu: 200m
+            cpu: 100m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -876,6 +876,7 @@ spec:
       - name: ts-auth-service
         image: codewisdom/ts-auth-service-with-jaeger:v1
         imagePullPolicy: IfNotPresent
+        args: ["java", "-Xmx400m",  "-jar", "/app/ts-auth-service-1.0.jar"]
         env:
           - name: JAVA_TOOL_OPTIONS
             value: >-
@@ -887,11 +888,11 @@ spec:
         - containerPort: 12340
         resources:
           requests:
-            cpu: 500m
-            memory: 1200Mi
+            cpu: 700m
+            memory: 800Mi
           limits:
-            cpu: 1500m
-            memory: 1200Mi
+            cpu: 700m
+            memory: 800Mi
         readinessProbe:
           tcpSocket:
             port: 12340
@@ -934,10 +935,10 @@ spec:
         resources:
           requests:
             cpu: 50m
-            memory: 160Mi
+            memory: 50Mi
           limits:
-            cpu: 200m
-            memory: 500Mi
+            cpu: 50m
+            memory: 50Mi
         readinessProbe:
           tcpSocket:
             port: 12862
@@ -989,7 +990,7 @@ spec:
             cpu: 50m
             memory: 160Mi
           limits:
-            cpu: 200m
+            cpu: 100m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -1240,6 +1241,7 @@ spec:
       - name: ts-preserve-service
         image: codewisdom/ts-preserve-service-with-jaeger:v1
         imagePullPolicy: IfNotPresent
+        args: ["java", "-Xmx400m",  "-jar", "/app/ts-preserve-service-1.0.jar"]
         env:
           - name: JAVA_TOOL_OPTIONS
             value: >-
@@ -1876,7 +1878,7 @@ spec:
       - name: ts-travel2-service
         image: codewisdom/ts-travel2-service-with-jaeger:v1
         imagePullPolicy: IfNotPresent
-        args: ["java", "-Xmx350m",  "-jar", "/app/ts-travel2-service-1.0.jar"]
+        args: ["java", "-Xmx200m",  "-jar", "/app/ts-travel2-service-1.0.jar"]
         env:
           - name: JAVA_TOOL_OPTIONS
             value: >-
@@ -1889,10 +1891,10 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 700Mi
+            memory: 200Mi
           limits:
             cpu: 100m
-            memory: 700Mi
+            memory: 400Mi
         readinessProbe:
           tcpSocket:
             port: 16346
@@ -1995,7 +1997,7 @@ spec:
         - containerPort: 12346
         resources:
           requests:
-            cpu: 600m
+            cpu: 300m
             memory: 800Mi
           limits:
             cpu: 600m
@@ -2095,10 +2097,10 @@ spec:
         resources:
           requests:
             cpu: 50m
-            memory: 160Mi
+            memory: 50Mi
           limits:
-            cpu: 200m
-            memory: 500Mi
+            cpu: 50m
+            memory: 50Mi
         readinessProbe:
           tcpSocket:
             port: 16101

--- a/manifests/train-ticket-base/app/ts-part2.yaml
+++ b/manifests/train-ticket-base/app/ts-part2.yaml
@@ -1876,6 +1876,7 @@ spec:
       - name: ts-travel2-service
         image: codewisdom/ts-travel2-service-with-jaeger:v1
         imagePullPolicy: IfNotPresent
+        args: ["java", "-Xmx350m",  "-jar", "/app/ts-travel2-service-1.0.jar"]
         env:
           - name: JAVA_TOOL_OPTIONS
             value: >-
@@ -1887,11 +1888,11 @@ spec:
         - containerPort: 16346
         resources:
           requests:
-            cpu: 200m
-            memory: 500Mi
+            cpu: 100m
+            memory: 700Mi
           limits:
-            cpu: 200m
-            memory: 750Mi
+            cpu: 100m
+            memory: 700Mi
         readinessProbe:
           tcpSocket:
             port: 16346
@@ -1982,6 +1983,7 @@ spec:
       - name: ts-travel-service
         image: codewisdom/ts-travel-service-with-jaeger:v1
         imagePullPolicy: IfNotPresent
+        args: ["java", "-Xmx400m",  "-jar", "/app/ts-travel-service-1.0.jar"]
         env:
           - name: JAVA_TOOL_OPTIONS
             value: >-
@@ -1994,10 +1996,10 @@ spec:
         resources:
           requests:
             cpu: 600m
-            memory: 1200Mi
+            memory: 800Mi
           limits:
             cpu: 600m
-            memory: 1200Mi
+            memory: 800Mi
         readinessProbe:
           tcpSocket:
             port: 12346

--- a/manifests/train-ticket-base/app/ts-part2.yaml
+++ b/manifests/train-ticket-base/app/ts-part2.yaml
@@ -3,17 +3,24 @@ kind: Deployment
 metadata:
   name: ts-admin-basic-info-service
   labels:
+    app.kubernetes.io/name: ts-admin-basic-info-service
+    app.kubernetes.io/part-of: ts-admin-basic-info
+    app.kubernetes.io/component: web
     runtime: jvm
 spec:
   selector:
     matchLabels:
-      app: ts-admin-basic-info-service
+      app.kubernetes.io/name: ts-admin-basic-info-service
+      app.kubernetes.io/part-of: ts-admin-basic-info
+      app.kubernetes.io/component: web
       runtime: jvm
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-admin-basic-info-service
+        app.kubernetes.io/name: ts-admin-basic-info-service
+        app.kubernetes.io/part-of: ts-admin-basic-info
+        app.kubernetes.io/component: web
         runtime: jvm
     spec:
       containers:
@@ -50,17 +57,24 @@ kind: Deployment
 metadata:
   name: ts-admin-order-service
   labels:
+    app.kubernetes.io/name: ts-admin-order-service
+    app.kubernetes.io/part-of: ts-admin-order
+    app.kubernetes.io/component: web
     runtime: jvm
 spec:
   selector:
     matchLabels:
-      app: ts-admin-order-service
+      app.kubernetes.io/name: ts-admin-order-service
+      app.kubernetes.io/part-of: ts-admin-order
+      app.kubernetes.io/component: web
       runtime: jvm
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-admin-order-service
+        app.kubernetes.io/name: ts-admin-order-service
+        app.kubernetes.io/part-of: ts-admin-order
+        app.kubernetes.io/component: web
         runtime: jvm
     spec:
       containers:
@@ -96,17 +110,24 @@ kind: Deployment
 metadata:
   name: ts-admin-route-service
   labels:
+    app.kubernetes.io/name: ts-admin-route-service
+    app.kubernetes.io/part-of: ts-admin-route
+    app.kubernetes.io/component: web
     runtime: jvm
 spec:
   selector:
     matchLabels:
-      app: ts-admin-route-service
+      app.kubernetes.io/name: ts-admin-route-service
+      app.kubernetes.io/part-of: ts-admin-route
+      app.kubernetes.io/component: web
       runtime: jvm
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-admin-route-service
+        app.kubernetes.io/name: ts-admin-route-service
+        app.kubernetes.io/part-of: ts-admin-route
+        app.kubernetes.io/component: web
         runtime: jvm
     spec:
       containers:
@@ -142,17 +163,24 @@ kind: Deployment
 metadata:
   name: ts-admin-travel-service
   labels:
+    app.kubernetes.io/name: ts-admin-travel-service
+    app.kubernetes.io/part-of: ts-admin-travel
+    app.kubernetes.io/component: web
     runtime: jvm
 spec:
   selector:
     matchLabels:
-      app: ts-admin-travel-service
+      app.kubernetes.io/name: ts-admin-travel-service
+      app.kubernetes.io/part-of: ts-admin-travel
+      app.kubernetes.io/component: web
       runtime: jvm
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-admin-travel-service
+        app.kubernetes.io/name: ts-admin-travel-service
+        app.kubernetes.io/part-of: ts-admin-travel
+        app.kubernetes.io/component: web
         runtime: jvm
     spec:
       containers:
@@ -188,17 +216,24 @@ kind: Deployment
 metadata:
   name: ts-admin-user-service
   labels:
+    app.kubernetes.io/name: ts-admin-user-service
+    app.kubernetes.io/part-of: ts-admin-user
+    app.kubernetes.io/component: web
     runtime: jvm
 spec:
   selector:
     matchLabels:
-      app: ts-admin-user-service
+      app.kubernetes.io/name: ts-admin-user-service
+      app.kubernetes.io/part-of: ts-admin-user
+      app.kubernetes.io/component: web
       runtime: jvm
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-admin-user-service
+        app.kubernetes.io/name: ts-admin-user-service
+        app.kubernetes.io/part-of: ts-admin-user
+        app.kubernetes.io/component: web
         runtime: jvm
     spec:
       containers:
@@ -234,17 +269,24 @@ kind: Deployment
 metadata:
   name: ts-assurance-service
   labels:
+    app.kubernetes.io/name: ts-assurance-service
+    app.kubernetes.io/part-of: ts-assurance
+    app.kubernetes.io/component: web
     runtime: jvm
 spec:
   selector:
     matchLabels:
-      app: ts-assurance-service
+      app.kubernetes.io/name: ts-assurance-service
+      app.kubernetes.io/part-of: ts-assurance
+      app.kubernetes.io/component: web
       runtime: jvm
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-assurance-service
+        app.kubernetes.io/name: ts-assurance-service
+        app.kubernetes.io/part-of: ts-assurance
+        app.kubernetes.io/component: web
         runtime: jvm
     spec:
       containers:
@@ -280,17 +322,24 @@ kind: Deployment
 metadata:
   name: ts-basic-service
   labels:
+    app.kubernetes.io/name: ts-basic-service
+    app.kubernetes.io/part-of: ts-basic
+    app.kubernetes.io/component: web
     runtime: jvm
 spec:
   selector:
     matchLabels:
-      app: ts-basic-service
+      app.kubernetes.io/name: ts-basic-service
+      app.kubernetes.io/part-of: ts-basic
+      app.kubernetes.io/component: web
       runtime: jvm
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-basic-service
+        app.kubernetes.io/name: ts-basic-service
+        app.kubernetes.io/part-of: ts-basic
+        app.kubernetes.io/component: web
         runtime: jvm
     spec:
       containers:
@@ -326,17 +375,24 @@ kind: Deployment
 metadata:
   name: ts-cancel-service
   labels:
+    app.kubernetes.io/name: ts-cancel-service
+    app.kubernetes.io/part-of: ts-cancel
+    app.kubernetes.io/component: web
     runtime: jvm
 spec:
   selector:
     matchLabels:
-      app: ts-cancel-service
+      app.kubernetes.io/name: ts-cancel-service
+      app.kubernetes.io/part-of: ts-cancel
+      app.kubernetes.io/component: web
       runtime: jvm
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-cancel-service
+        app.kubernetes.io/name: ts-cancel-service
+        app.kubernetes.io/part-of: ts-cancel
+        app.kubernetes.io/component: web
         runtime: jvm
     spec:
       containers:
@@ -372,17 +428,24 @@ kind: Deployment
 metadata:
   name: ts-config-service
   labels:
+    app.kubernetes.io/name: ts-config-service
+    app.kubernetes.io/part-of: ts-config
+    app.kubernetes.io/component: web
     runtime: jvm
 spec:
   selector:
     matchLabels:
-      app: ts-config-service
+      app.kubernetes.io/name: ts-config-service
+      app.kubernetes.io/part-of: ts-config
+      app.kubernetes.io/component: web
       runtime: jvm
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-config-service
+        app.kubernetes.io/name: ts-config-service
+        app.kubernetes.io/part-of: ts-config
+        app.kubernetes.io/component: web
         runtime: jvm
     spec:
       containers:
@@ -418,17 +481,24 @@ kind: Deployment
 metadata:
   name: ts-consign-price-service
   labels:
+    app.kubernetes.io/name: ts-config-price-service
+    app.kubernetes.io/part-of: ts-config-price
+    app.kubernetes.io/component: web
     runtime: jvm
 spec:
   selector:
     matchLabels:
-      app: ts-consign-price-service
+      app.kubernetes.io/name: ts-config-price-service
+      app.kubernetes.io/part-of: ts-config-price
+      app.kubernetes.io/component: web
       runtime: jvm
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-consign-price-service
+        app.kubernetes.io/name: ts-config-price-service
+        app.kubernetes.io/part-of: ts-config-price
+        app.kubernetes.io/component: web
         runtime: jvm
     spec:
       containers:
@@ -464,17 +534,24 @@ kind: Deployment
 metadata:
   name: ts-consign-service
   labels:
+    app.kubernetes.io/name: ts-consign-service
+    app.kubernetes.io/part-of: ts-consign
+    app.kubernetes.io/component: web
     runtime: jvm
 spec:
   selector:
     matchLabels:
-      app: ts-consign-service
+      app.kubernetes.io/name: ts-consign-service
+      app.kubernetes.io/part-of: ts-consign
+      app.kubernetes.io/component: web
       runtime: jvm
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-consign-service
+        app.kubernetes.io/name: ts-consign-service
+        app.kubernetes.io/part-of: ts-consign
+        app.kubernetes.io/component: web
         runtime: jvm
     spec:
       containers:
@@ -510,17 +587,24 @@ kind: Deployment
 metadata:
   name: ts-contacts-service
   labels:
+    app.kubernetes.io/name: ts-contacts-service
+    app.kubernetes.io/part-of: ts-contacts
+    app.kubernetes.io/component: web
     runtime: jvm
 spec:
   selector:
     matchLabels:
-      app: ts-contacts-service
+      app.kubernetes.io/name: ts-contacts-service
+      app.kubernetes.io/part-of: ts-contacts
+      app.kubernetes.io/component: web
       runtime: jvm
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-contacts-service
+        app.kubernetes.io/name: ts-contacts-service
+        app.kubernetes.io/part-of: ts-contacts
+        app.kubernetes.io/component: web
         runtime: jvm
     spec:
       containers:
@@ -556,17 +640,24 @@ kind: Deployment
 metadata:
   name: ts-execute-service
   labels:
+    app.kubernetes.io/name: ts-execute-service
+    app.kubernetes.io/part-of: ts-execute
+    app.kubernetes.io/component: web
     runtime: jvm
 spec:
   selector:
     matchLabels:
-      app: ts-execute-service
+      app.kubernetes.io/name: ts-execute-service
+      app.kubernetes.io/part-of: ts-execute
+      app.kubernetes.io/component: web
       runtime: jvm
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-execute-service
+        app.kubernetes.io/name: ts-execute-service
+        app.kubernetes.io/part-of: ts-execute
+        app.kubernetes.io/component: web
         runtime: jvm
     spec:
       containers:
@@ -602,17 +693,24 @@ kind: Deployment
 metadata:
   name: ts-food-map-service
   labels:
+    app.kubernetes.io/name: ts-food-map-service
+    app.kubernetes.io/part-of: ts-food-map
+    app.kubernetes.io/component: web
     runtime: jvm
 spec:
   selector:
     matchLabels:
-      app: ts-food-map-service
+      app.kubernetes.io/name: ts-food-map-service
+      app.kubernetes.io/part-of: ts-food-map
+      app.kubernetes.io/component: web
       runtime: jvm
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-food-map-service
+        app.kubernetes.io/name: ts-food-map-service
+        app.kubernetes.io/part-of: ts-food-map
+        app.kubernetes.io/component: web
         runtime: jvm
     spec:
       containers:
@@ -648,17 +746,24 @@ kind: Deployment
 metadata:
   name: ts-food-service
   labels:
+    app.kubernetes.io/name: ts-food-service
+    app.kubernetes.io/part-of: ts-food
+    app.kubernetes.io/component: web
     runtime: jvm
 spec:
   selector:
     matchLabels:
-      app: ts-food-service
+      app.kubernetes.io/name: ts-food-service
+      app.kubernetes.io/part-of: ts-food
+      app.kubernetes.io/component: web
       runtime: jvm
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-food-service
+        app.kubernetes.io/name: ts-food-service
+        app.kubernetes.io/part-of: ts-food
+        app.kubernetes.io/component: web
         runtime: jvm
     spec:
       containers:
@@ -694,17 +799,24 @@ kind: Deployment
 metadata:
   name: ts-inside-payment-service
   labels:
+    app.kubernetes.io/name: ts-inside-payment-service
+    app.kubernetes.io/part-of: ts-inside-payment
+    app.kubernetes.io/component: web
     runtime: jvm
 spec:
   selector:
     matchLabels:
-      app: ts-inside-payment-service
+      app.kubernetes.io/name: ts-inside-payment-service
+      app.kubernetes.io/part-of: ts-inside-payment
+      app.kubernetes.io/component: web
       runtime: jvm
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-inside-payment-service
+        app.kubernetes.io/name: ts-inside-payment-service
+        app.kubernetes.io/part-of: ts-inside-payment
+        app.kubernetes.io/component: web
         runtime: jvm
     spec:
       containers:
@@ -740,17 +852,24 @@ kind: Deployment
 metadata:
   name: ts-auth-service
   labels:
+    app.kubernetes.io/name: ts-auth-service
+    app.kubernetes.io/part-of: ts-auth
+    app.kubernetes.io/component: web
     runtime: jvm
 spec:
   selector:
     matchLabels:
-      app: ts-auth-service
+      app.kubernetes.io/name: ts-auth-service
+      app.kubernetes.io/part-of: ts-auth
+      app.kubernetes.io/component: web
       runtime: jvm
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-auth-service
+        app.kubernetes.io/name: ts-auth-service
+        app.kubernetes.io/part-of: ts-auth
+        app.kubernetes.io/component: web
         runtime: jvm
     spec:
       containers:
@@ -786,17 +905,24 @@ kind: Deployment
 metadata:
   name: ts-news-service
   labels:
+    app.kubernetes.io/name: ts-news-service
+    app.kubernetes.io/part-of: ts-news
+    app.kubernetes.io/component: web
     runtime: go
 spec:
   selector:
     matchLabels:
-      app: ts-news-service
+      app.kubernetes.io/name: ts-news-service
+      app.kubernetes.io/part-of: ts-news
+      app.kubernetes.io/component: web
       runtime: go
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-news-service
+        app.kubernetes.io/name: ts-news-service
+        app.kubernetes.io/part-of: ts-news
+        app.kubernetes.io/component: web
         runtime: go
     spec:
       containers:
@@ -825,17 +951,24 @@ kind: Deployment
 metadata:
   name: ts-notification-service
   labels:
+    app.kubernetes.io/name: ts-notification-service
+    app.kubernetes.io/part-of: ts-notification
+    app.kubernetes.io/component: web
     runtime: jvm
 spec:
   selector:
     matchLabels:
-      app: ts-notification-service
+      app.kubernetes.io/name: ts-notification-service
+      app.kubernetes.io/part-of: ts-notification
+      app.kubernetes.io/component: web
       runtime: jvm
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-notification-service
+        app.kubernetes.io/name: ts-notification-service
+        app.kubernetes.io/part-of: ts-notification
+        app.kubernetes.io/component: web
         runtime: jvm
     spec:
       containers:
@@ -871,17 +1004,24 @@ kind: Deployment
 metadata:
   name: ts-order-other-service
   labels:
+    app.kubernetes.io/name: ts-order-other-service
+    app.kubernetes.io/part-of: ts-order-other
+    app.kubernetes.io/component: web
     runtime: jvm
 spec:
   selector:
     matchLabels:
-      app: ts-order-other-service
+      app.kubernetes.io/name: ts-order-other-service
+      app.kubernetes.io/part-of: ts-order-other
+      app.kubernetes.io/component: web
       runtime: jvm
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-order-other-service
+        app.kubernetes.io/name: ts-order-other-service
+        app.kubernetes.io/part-of: ts-order-other
+        app.kubernetes.io/component: web
         runtime: jvm
     spec:
       containers:
@@ -917,17 +1057,24 @@ kind: Deployment
 metadata:
   name: ts-order-service
   labels:
+    app.kubernetes.io/name: ts-order-service
+    app.kubernetes.io/part-of: ts-order
+    app.kubernetes.io/component: web
     runtime: jvm
 spec:
   selector:
     matchLabels:
-      app: ts-order-service
+      app.kubernetes.io/name: ts-order-service
+      app.kubernetes.io/part-of: ts-order
+      app.kubernetes.io/component: web
       runtime: jvm
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-order-service
+        app.kubernetes.io/name: ts-order-service
+        app.kubernetes.io/part-of: ts-order
+        app.kubernetes.io/component: web
         runtime: jvm
     spec:
       containers:
@@ -963,17 +1110,24 @@ kind: Deployment
 metadata:
   name: ts-payment-service
   labels:
+    app.kubernetes.io/name: ts-payment-service
+    app.kubernetes.io/part-of: ts-payment
+    app.kubernetes.io/component: web
     runtime: jvm
 spec:
   selector:
     matchLabels:
-      app: ts-payment-service
+      app.kubernetes.io/name: ts-payment-service
+      app.kubernetes.io/part-of: ts-payment
+      app.kubernetes.io/component: web
       runtime: jvm
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-payment-service
+        app.kubernetes.io/name: ts-payment-service
+        app.kubernetes.io/part-of: ts-payment
+        app.kubernetes.io/component: web
         runtime: jvm
     spec:
       containers:
@@ -1009,17 +1163,24 @@ kind: Deployment
 metadata:
   name: ts-preserve-other-service
   labels:
+    app.kubernetes.io/name: ts-preserve-other-service
+    app.kubernetes.io/part-of: ts-preserve-other
+    app.kubernetes.io/component: web
     runtime: jvm
 spec:
   selector:
     matchLabels:
-      app: ts-preserve-other-service
+      app.kubernetes.io/name: ts-preserve-other-service
+      app.kubernetes.io/part-of: ts-preserve-other
+      app.kubernetes.io/component: web
       runtime: jvm
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-preserve-other-service
+        app.kubernetes.io/name: ts-preserve-other-service
+        app.kubernetes.io/part-of: ts-preserve-other
+        app.kubernetes.io/component: web
         runtime: jvm
     spec:
       containers:
@@ -1055,17 +1216,24 @@ kind: Deployment
 metadata:
   name: ts-preserve-service
   labels:
+    app.kubernetes.io/name: ts-preserve-service
+    app.kubernetes.io/part-of: ts-preserve
+    app.kubernetes.io/component: web
     runtime: jvm
 spec:
   selector:
     matchLabels:
-      app: ts-preserve-service
+      app.kubernetes.io/name: ts-preserve-service
+      app.kubernetes.io/part-of: ts-preserve
+      app.kubernetes.io/component: web
       runtime: jvm
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-preserve-service
+        app.kubernetes.io/name: ts-preserve-service
+        app.kubernetes.io/part-of: ts-preserve
+        app.kubernetes.io/component: web
         runtime: jvm
     spec:
       containers:
@@ -1101,17 +1269,24 @@ kind: Deployment
 metadata:
   name: ts-price-service
   labels:
+    app.kubernetes.io/name: ts-price-service
+    app.kubernetes.io/part-of: ts-price
+    app.kubernetes.io/component: web
     runtime: jvm
 spec:
   selector:
     matchLabels:
-      app: ts-price-service
+      app.kubernetes.io/name: ts-price-service
+      app.kubernetes.io/part-of: ts-price
+      app.kubernetes.io/component: web
       runtime: jvm
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-price-service
+        app.kubernetes.io/name: ts-price-service
+        app.kubernetes.io/part-of: ts-price
+        app.kubernetes.io/component: web
         runtime: jvm
     spec:
       containers:
@@ -1147,17 +1322,24 @@ kind: Deployment
 metadata:
   name: ts-rebook-service
   labels:
+    app.kubernetes.io/name: ts-rebook-service
+    app.kubernetes.io/part-of: ts-rebook
+    app.kubernetes.io/component: web
     runtime: jvm
 spec:
   selector:
     matchLabels:
-      app: ts-rebook-service
+      app.kubernetes.io/name: ts-rebook-service
+      app.kubernetes.io/part-of: ts-rebook
+      app.kubernetes.io/component: web
       runtime: jvm
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-rebook-service
+        app.kubernetes.io/name: ts-rebook-service
+        app.kubernetes.io/part-of: ts-rebook
+        app.kubernetes.io/component: web
         runtime: jvm
     spec:
       containers:
@@ -1193,17 +1375,24 @@ kind: Deployment
 metadata:
   name: ts-route-plan-service
   labels:
+    app.kubernetes.io/name: ts-route-plan-service
+    app.kubernetes.io/part-of: ts-route-plan
+    app.kubernetes.io/component: web
     runtime: jvm
 spec:
   selector:
     matchLabels:
-      app: ts-route-plan-service
+      app.kubernetes.io/name: ts-route-plan-service
+      app.kubernetes.io/part-of: ts-route-plan
+      app.kubernetes.io/component: web
       runtime: jvm
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-route-plan-service
+        app.kubernetes.io/name: ts-route-plan-service
+        app.kubernetes.io/part-of: ts-route-plan
+        app.kubernetes.io/component: web
         runtime: jvm
     spec:
       containers:
@@ -1239,17 +1428,24 @@ kind: Deployment
 metadata:
   name: ts-route-service
   labels:
+    app.kubernetes.io/name: ts-route-service
+    app.kubernetes.io/part-of: ts-route
+    app.kubernetes.io/component: web
     runtime: jvm
 spec:
   selector:
     matchLabels:
-      app: ts-route-service
+      app.kubernetes.io/name: ts-route-service
+      app.kubernetes.io/part-of: ts-route
+      app.kubernetes.io/component: web
       runtime: jvm
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-route-service
+        app.kubernetes.io/name: ts-route-service
+        app.kubernetes.io/part-of: ts-route
+        app.kubernetes.io/component: web
         runtime: jvm
     spec:
       containers:
@@ -1285,17 +1481,24 @@ kind: Deployment
 metadata:
   name: ts-seat-service
   labels:
+    app.kubernetes.io/name: ts-seat-service
+    app.kubernetes.io/part-of: ts-seat
+    app.kubernetes.io/component: web
     runtime: jvm
 spec:
   selector:
     matchLabels:
-      app: ts-seat-service
+      app.kubernetes.io/name: ts-seat-service
+      app.kubernetes.io/part-of: ts-seat
+      app.kubernetes.io/component: web
       runtime: jvm
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-seat-service
+        app.kubernetes.io/name: ts-seat-service
+        app.kubernetes.io/part-of: ts-seat
+        app.kubernetes.io/component: web
         runtime: jvm
     spec:
       containers:
@@ -1331,17 +1534,24 @@ kind: Deployment
 metadata:
   name: ts-security-service
   labels:
+    app.kubernetes.io/name: ts-security-service
+    app.kubernetes.io/part-of: ts-security
+    app.kubernetes.io/component: web
     runtime: jvm
 spec:
   selector:
     matchLabels:
-      app: ts-security-service
+      app.kubernetes.io/name: ts-security-service
+      app.kubernetes.io/part-of: ts-security
+      app.kubernetes.io/component: web
       runtime: jvm
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-security-service
+        app.kubernetes.io/name: ts-security-service
+        app.kubernetes.io/part-of: ts-security
+        app.kubernetes.io/component: web
         runtime: jvm
     spec:
       containers:
@@ -1377,17 +1587,24 @@ kind: Deployment
 metadata:
   name: ts-user-service
   labels:
+    app.kubernetes.io/name: ts-user-service
+    app.kubernetes.io/part-of: ts-user
+    app.kubernetes.io/component: web
     runtime: jvm
 spec:
   selector:
     matchLabels:
-      app: ts-user-service
+      app.kubernetes.io/name: ts-user-service
+      app.kubernetes.io/part-of: ts-user
+      app.kubernetes.io/component: web
       runtime: jvm
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-user-service
+        app.kubernetes.io/name: ts-user-service
+        app.kubernetes.io/part-of: ts-user
+        app.kubernetes.io/component: web
         runtime: jvm
     spec:
       containers:
@@ -1423,17 +1640,24 @@ kind: Deployment
 metadata:
   name: ts-station-service
   labels:
+    app.kubernetes.io/name: ts-station-service
+    app.kubernetes.io/part-of: ts-station
+    app.kubernetes.io/component: web
     runtime: jvm
 spec:
   selector:
     matchLabels:
-      app: ts-station-service
+      app.kubernetes.io/name: ts-station-service
+      app.kubernetes.io/part-of: ts-station
+      app.kubernetes.io/component: web
       runtime: jvm
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-station-service
+        app.kubernetes.io/name: ts-station-service
+        app.kubernetes.io/part-of: ts-station
+        app.kubernetes.io/component: web
         runtime: jvm
     spec:
       containers:
@@ -1469,17 +1693,24 @@ kind: Deployment
 metadata:
   name: ts-ticket-office-service
   labels:
+    app.kubernetes.io/name: ts-ticket-office-service
+    app.kubernetes.io/part-of: ts-ticket-office
+    app.kubernetes.io/component: web
     runtime: nodejs
 spec:
   selector:
     matchLabels:
-      app: ts-ticket-office-service
+      app.kubernetes.io/name: ts-ticket-office-service
+      app.kubernetes.io/part-of: ts-ticket-office
+      app.kubernetes.io/component: web
       runtime: nodejs
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-ticket-office-service
+        app.kubernetes.io/name: ts-ticket-office-service
+        app.kubernetes.io/part-of: ts-ticket-office
+        app.kubernetes.io/component: web
         runtime: nodejs
     spec:
       containers:
@@ -1515,17 +1746,24 @@ kind: Deployment
 metadata:
   name: ts-ticketinfo-service
   labels:
+    app.kubernetes.io/name: ts-ticketinfo-service
+    app.kubernetes.io/part-of: ts-ticketinfo
+    app.kubernetes.io/component: web
     runtime: jvm
 spec:
   selector:
     matchLabels:
-      app: ts-ticketinfo-service
+      app.kubernetes.io/name: ts-ticketinfo-service
+      app.kubernetes.io/part-of: ts-ticketinfo
+      app.kubernetes.io/component: web
       runtime: jvm
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-ticketinfo-service
+        app.kubernetes.io/name: ts-ticketinfo-service
+        app.kubernetes.io/part-of: ts-ticketinfo
+        app.kubernetes.io/component: web
         runtime: jvm
     spec:
       containers:
@@ -1561,17 +1799,24 @@ kind: Deployment
 metadata:
   name: ts-train-service
   labels:
+    app.kubernetes.io/name: ts-train-service
+    app.kubernetes.io/part-of: ts-train
+    app.kubernetes.io/component: web
     runtime: jvm
 spec:
   selector:
     matchLabels:
-      app: ts-train-service
+      app.kubernetes.io/name: ts-train-service
+      app.kubernetes.io/part-of: ts-train
+      app.kubernetes.io/component: web
       runtime: jvm
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-train-service
+        app.kubernetes.io/name: ts-train-service
+        app.kubernetes.io/part-of: ts-train
+        app.kubernetes.io/component: web
         runtime: jvm
     spec:
       containers:
@@ -1607,17 +1852,24 @@ kind: Deployment
 metadata:
   name: ts-travel2-service
   labels:
+    app.kubernetes.io/name: ts-travel2-service
+    app.kubernetes.io/part-of: ts-travel2
+    app.kubernetes.io/component: web
     runtime: jvm
 spec:
   selector:
     matchLabels:
-      app: ts-travel2-service
+      app.kubernetes.io/name: ts-travel2-service
+      app.kubernetes.io/part-of: ts-travel2
+      app.kubernetes.io/component: web
       runtime: jvm
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-travel2-service
+        app.kubernetes.io/name: ts-travel2-service
+        app.kubernetes.io/part-of: ts-travel2
+        app.kubernetes.io/component: web
         runtime: jvm
     spec:
       containers:
@@ -1653,17 +1905,24 @@ kind: Deployment
 metadata:
   name: ts-travel-plan-service
   labels:
+    app.kubernetes.io/name: ts-travel-plan-service
+    app.kubernetes.io/part-of: ts-travel-plan
+    app.kubernetes.io/component: web
     runtime: jvm
 spec:
   selector:
     matchLabels:
-      app: ts-travel-plan-service
+      app.kubernetes.io/name: ts-travel-plan-service
+      app.kubernetes.io/part-of: ts-travel-plan
+      app.kubernetes.io/component: web
       runtime: jvm
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-travel-plan-service
+        app.kubernetes.io/name: ts-travel-plan-service
+        app.kubernetes.io/part-of: ts-travel-plan
+        app.kubernetes.io/component: web
         runtime: jvm
     spec:
       containers:
@@ -1699,17 +1958,24 @@ kind: Deployment
 metadata:
   name: ts-travel-service
   labels:
+    app.kubernetes.io/name: ts-travel-service
+    app.kubernetes.io/part-of: ts-travel
+    app.kubernetes.io/component: web
     runtime: jvm
 spec:
   selector:
     matchLabels:
-      app: ts-travel-service
+      app.kubernetes.io/name: ts-travel-service
+      app.kubernetes.io/part-of: ts-travel
+      app.kubernetes.io/component: web
       runtime: jvm
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-travel-service
+        app.kubernetes.io/name: ts-travel-service
+        app.kubernetes.io/part-of: ts-travel
+        app.kubernetes.io/component: web
         runtime: jvm
     spec:
       containers:
@@ -1745,17 +2011,24 @@ kind: Deployment
 metadata:
   name: ts-verification-code-service
   labels:
+    app.kubernetes.io/name: ts-verification-code-service
+    app.kubernetes.io/part-of: ts-verification-code
+    app.kubernetes.io/component: web
     runtime: jvm
 spec:
   selector:
     matchLabels:
-      app: ts-verification-code-service
+      app.kubernetes.io/name: ts-verification-code-service
+      app.kubernetes.io/part-of: ts-verification-code
+      app.kubernetes.io/component: web
       runtime: jvm
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-verification-code-service
+        app.kubernetes.io/name: ts-verification-code-service
+        app.kubernetes.io/part-of: ts-verification-code
+        app.kubernetes.io/component: web
         runtime: jvm
     spec:
       containers:
@@ -1791,17 +2064,24 @@ kind: Deployment
 metadata:
   name: ts-voucher-service
   labels:
+    app.kubernetes.io/name: ts-voucher-service
+    app.kubernetes.io/part-of: ts-voucher
+    app.kubernetes.io/component: web
     runtime: python
 spec:
   selector:
     matchLabels:
-      app: ts-voucher-service
+      app.kubernetes.io/name: ts-voucher-service
+      app.kubernetes.io/part-of: ts-voucher
+      app.kubernetes.io/component: web
       runtime: python
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-voucher-service
+        app.kubernetes.io/name: ts-voucher-service
+        app.kubernetes.io/part-of: ts-voucher
+        app.kubernetes.io/component: web
         runtime: python
     spec:
       containers:
@@ -1829,12 +2109,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-admin-basic-info-service
+  labels:
+    app.kubernetes.io/name: ts-admin-basic-info-service
+    app.kubernetes.io/part-of: ts-admin-basic-info
+    app.kubernetes.io/component: web
 spec:
   ports:
     - name: http
       port: 18767
   selector:
-    app: ts-admin-basic-info-service
+    app.kubernetes.io/name: ts-admin-basic-info-service
+    app.kubernetes.io/part-of: ts-admin-basic-info
+    app.kubernetes.io/component: web
 
 ---
 
@@ -1842,12 +2128,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-admin-order-service
+  labels:
+    app.kubernetes.io/name: ts-admin-order-service
+    app.kubernetes.io/part-of: ts-admin-basic-info
+    app.kubernetes.io/component: web
 spec:
   ports:
     - name: http
       port: 16112
   selector:
-    app: ts-admin-order-service
+    app.kubernetes.io/name: ts-admin-order-service
+    app.kubernetes.io/part-of: ts-admin-basic-info
+    app.kubernetes.io/component: web
 
 ---
 
@@ -1855,12 +2147,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-admin-route-service
+  labels:
+    app.kubernetes.io/name: ts-admin-route-service
+    app.kubernetes.io/part-of: ts-admin-route
+    app.kubernetes.io/component: web
 spec:
   ports:
     - name: http
       port: 16113
   selector:
-    app: ts-admin-route-service
+    app.kubernetes.io/name: ts-admin-route-service
+    app.kubernetes.io/part-of: ts-admin-route
+    app.kubernetes.io/component: web
 
 ---
 
@@ -1868,12 +2166,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-admin-travel-service
+  labels:
+    app.kubernetes.io/name: ts-admin-travel-service
+    app.kubernetes.io/part-of: ts-admin-travel
+    app.kubernetes.io/component: web
 spec:
   ports:
     - name: http
       port: 16114
   selector:
-    app: ts-admin-travel-service
+    app.kubernetes.io/name: ts-admin-travel-service
+    app.kubernetes.io/part-of: ts-admin-travel
+    app.kubernetes.io/component: web
 
 ---
 
@@ -1881,12 +2185,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-admin-user-service
+  labels:
+    app.kubernetes.io/name: ts-admin-user-service
+    app.kubernetes.io/part-of: ts-admin-user
+    app.kubernetes.io/component: web
 spec:
   ports:
     - name: http
       port: 16115
   selector:
-    app: ts-admin-user-service
+    app.kubernetes.io/name: ts-admin-user-service
+    app.kubernetes.io/part-of: ts-admin-user
+    app.kubernetes.io/component: web
 
 ---
 
@@ -1894,12 +2204,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-assurance-service
+  labels:
+    app.kubernetes.io/name: ts-assurance-service
+    app.kubernetes.io/part-of: ts-assurance
+    app.kubernetes.io/component: web
 spec:
   ports:
     - name: http
       port: 18888
   selector:
-    app: ts-assurance-service
+    app.kubernetes.io/name: ts-assurance-service
+    app.kubernetes.io/part-of: ts-assurance
+    app.kubernetes.io/component: web
 
 ---
 
@@ -1907,12 +2223,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-basic-service
+  labels:
+    app.kubernetes.io/name: ts-basic-service
+    app.kubernetes.io/part-of: ts-basic
+    app.kubernetes.io/component: web
 spec:
   ports:
     - name: http
       port: 15680
   selector:
-    app: ts-basic-service
+    app.kubernetes.io/name: ts-basic-service
+    app.kubernetes.io/part-of: ts-basic
+    app.kubernetes.io/component: web
 
 ---
 
@@ -1920,12 +2242,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-cancel-service
+  labels:
+    app.kubernetes.io/name: ts-cancel-service
+    app.kubernetes.io/part-of: ts-cancel
+    app.kubernetes.io/component: web
 spec:
   ports:
     - name: http
       port: 18885
   selector:
-    app: ts-cancel-service
+    app.kubernetes.io/name: ts-cancel-service
+    app.kubernetes.io/part-of: ts-cancel
+    app.kubernetes.io/component: web
 
 ---
 
@@ -1933,12 +2261,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-config-service
+  labels:
+    app.kubernetes.io/name: ts-config-service
+    app.kubernetes.io/part-of: ts-config
+    app.kubernetes.io/component: web
 spec:
   ports:
     - name: http
       port: 15679
   selector:
-    app: ts-config-service
+    app.kubernetes.io/name: ts-config-service
+    app.kubernetes.io/part-of: ts-config
+    app.kubernetes.io/component: web
 
 ---
 
@@ -1946,12 +2280,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-consign-price-service
+  labels:
+    app.kubernetes.io/name: ts-consign-price-service
+    app.kubernetes.io/part-of: ts-consign-price
+    app.kubernetes.io/component: web
 spec:
   ports:
     - name: http
       port: 16110
   selector:
-    app: ts-consign-price-service
+    app.kubernetes.io/name: ts-consign-price-service
+    app.kubernetes.io/part-of: ts-consign-price
+    app.kubernetes.io/component: web
 
 ---
 
@@ -1959,12 +2299,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-consign-service
+  labels:
+    app.kubernetes.io/name: ts-consign-service
+    app.kubernetes.io/part-of: ts-consign
+    app.kubernetes.io/component: web
 spec:
   ports:
     - name: http
       port: 16111
   selector:
-    app: ts-consign-service
+    app.kubernetes.io/name: ts-consign-service
+    app.kubernetes.io/part-of: ts-consign
+    app.kubernetes.io/component: web
 
 ---
 
@@ -1972,12 +2318,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-contacts-service
+  labels:
+    app.kubernetes.io/name: ts-contacts-service
+    app.kubernetes.io/part-of: ts-contacts
+    app.kubernetes.io/component: web
 spec:
   ports:
     - name: http
       port: 12347
   selector:
-    app: ts-contacts-service
+    app.kubernetes.io/name: ts-contacts-service
+    app.kubernetes.io/part-of: ts-contacts
+    app.kubernetes.io/component: web
 
 ---
 
@@ -1985,12 +2337,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-execute-service
+  labels:
+    app.kubernetes.io/name: ts-execute-service
+    app.kubernetes.io/part-of: ts-execute
+    app.kubernetes.io/component: web
 spec:
   ports:
     - name: http
       port: 12386
   selector:
-    app: ts-execute-service
+    app.kubernetes.io/name: ts-execute-service
+    app.kubernetes.io/part-of: ts-execute
+    app.kubernetes.io/component: web
 
 ---
 
@@ -1998,12 +2356,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-food-map-service
+  labels:
+    app.kubernetes.io/name: ts-food-map-service
+    app.kubernetes.io/part-of: ts-food-map
+    app.kubernetes.io/component: web
 spec:
   ports:
     - name: http
       port: 18855
   selector:
-    app: ts-food-map-service
+    app.kubernetes.io/name: ts-food-map-service
+    app.kubernetes.io/part-of: ts-food-map
+    app.kubernetes.io/component: web
 
 ---
 
@@ -2011,12 +2375,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-food-service
+  labels:
+    app.kubernetes.io/name: ts-food-service
+    app.kubernetes.io/part-of: ts-food
+    app.kubernetes.io/component: web
 spec:
   ports:
     - name: http
       port: 18856
   selector:
-    app: ts-food-service
+    app.kubernetes.io/name: ts-food-service
+    app.kubernetes.io/part-of: ts-food
+    app.kubernetes.io/component: web
 
 ---
 
@@ -2024,12 +2394,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-inside-payment-service
+  labels:
+    app.kubernetes.io/name: ts-inside-payment-service
+    app.kubernetes.io/part-of: ts-inside-payment
+    app.kubernetes.io/component: web
 spec:
   ports:
     - name: http
       port: 18673
   selector:
-    app: ts-inside-payment-service
+    app.kubernetes.io/name: ts-inside-payment-service
+    app.kubernetes.io/part-of: ts-inside-payment
+    app.kubernetes.io/component: web
 
 ---
 
@@ -2037,12 +2413,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-user-service
+  labels:
+    app.kubernetes.io/name: ts-user-service
+    app.kubernetes.io/part-of: ts-user
+    app.kubernetes.io/component: web
 spec:
   ports:
     - name: http
       port: 12342
   selector:
-    app: ts-user-service
+    app.kubernetes.io/name: ts-user-service
+    app.kubernetes.io/part-of: ts-user
+    app.kubernetes.io/component: web
 
 ---
 
@@ -2050,12 +2432,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-notification-service
+  labels:
+    app.kubernetes.io/name: ts-notification-service
+    app.kubernetes.io/part-of: ts-notification
+    app.kubernetes.io/component: web
 spec:
   ports:
     - name: http
       port: 17853
   selector:
-    app: ts-notification-service
+    app.kubernetes.io/name: ts-notification-service
+    app.kubernetes.io/part-of: ts-notification
+    app.kubernetes.io/component: web
 
 ---
 
@@ -2063,12 +2451,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-news-service
+  labels:
+    app.kubernetes.io/name: ts-news-service
+    app.kubernetes.io/part-of: ts-news
+    app.kubernetes.io/component: web
 spec:
   ports:
     - name: http
       port: 12862
   selector:
-    app: ts-news-service
+    app.kubernetes.io/name: ts-news-service
+    app.kubernetes.io/part-of: ts-news
+    app.kubernetes.io/component: web
 
 ---
 
@@ -2076,12 +2470,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-order-other-service
+  labels:
+    app.kubernetes.io/name: ts-order-other-service
+    app.kubernetes.io/part-of: ts-order-other
+    app.kubernetes.io/component: web
 spec:
   ports:
     - name: http
       port: 12032
   selector:
-    app: ts-order-other-service
+    app.kubernetes.io/name: ts-order-other-service
+    app.kubernetes.io/part-of: ts-order-other
+    app.kubernetes.io/component: web
 
 ---
 
@@ -2089,12 +2489,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-order-service
+  labels:
+    app.kubernetes.io/name: ts-order-service
+    app.kubernetes.io/part-of: ts-order
+    app.kubernetes.io/component: web
 spec:
   ports:
     - name: http
       port: 12031
   selector:
-    app: ts-order-service
+    app.kubernetes.io/name: ts-order-service
+    app.kubernetes.io/part-of: ts-order
+    app.kubernetes.io/component: web
 
 ---
 
@@ -2102,12 +2508,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-payment-service
+  labels:
+    app.kubernetes.io/name: ts-payment-service
+    app.kubernetes.io/part-of: ts-payment
+    app.kubernetes.io/component: web
 spec:
   ports:
     - name: http
       port: 19001
   selector:
-    app: ts-payment-service
+    app.kubernetes.io/name: ts-payment-service
+    app.kubernetes.io/part-of: ts-payment
+    app.kubernetes.io/component: web
 
 ---
 
@@ -2115,12 +2527,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-preserve-other-service
+  labels:
+    app.kubernetes.io/name: ts-preserve-other-service
+    app.kubernetes.io/part-of: ts-preserve-other
+    app.kubernetes.io/component: web
 spec:
   ports:
     - name: http
       port: 14569
   selector:
-    app: ts-preserve-other-service
+    app.kubernetes.io/name: ts-preserve-other-service
+    app.kubernetes.io/part-of: ts-preserve-other
+    app.kubernetes.io/component: web
 
 ---
 
@@ -2128,12 +2546,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-preserve-service
+  labels:
+    app.kubernetes.io/name: ts-preserve-service
+    app.kubernetes.io/part-of: ts-preserve
+    app.kubernetes.io/component: web
 spec:
   ports:
     - name: http
       port: 14568
   selector:
-    app: ts-preserve-service
+    app.kubernetes.io/name: ts-preserve-service
+    app.kubernetes.io/part-of: ts-preserve
+    app.kubernetes.io/component: web
 
 ---
 
@@ -2141,12 +2565,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-price-service
+  labels:
+    app.kubernetes.io/name: ts-price-service
+    app.kubernetes.io/part-of: ts-price
+    app.kubernetes.io/component: web
 spec:
   ports:
     - name: http
       port: 16579
   selector:
-    app: ts-price-service
+    app.kubernetes.io/name: ts-price-service
+    app.kubernetes.io/part-of: ts-price
+    app.kubernetes.io/component: web
 
 ---
 
@@ -2154,12 +2584,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-rebook-service
+  labels:
+    app.kubernetes.io/name: ts-rebook-service
+    app.kubernetes.io/part-of: ts-rebook
+    app.kubernetes.io/component: web
 spec:
   ports:
     - name: http
       port: 18886
   selector:
-    app: ts-rebook-service
+    app.kubernetes.io/name: ts-rebook-service
+    app.kubernetes.io/part-of: ts-rebook
+    app.kubernetes.io/component: web
 
 ---
 
@@ -2167,12 +2603,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-route-plan-service
+  labels:
+    app.kubernetes.io/name: ts-route-plan-service
+    app.kubernetes.io/part-of: ts-route-plan
+    app.kubernetes.io/component: web
 spec:
   ports:
     - name: http
       port: 14578
   selector:
-    app: ts-route-plan-service
+    app.kubernetes.io/name: ts-route-plan-service
+    app.kubernetes.io/part-of: ts-route-plan
+    app.kubernetes.io/component: web
 
 ---
 
@@ -2180,12 +2622,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-route-service
+  labels:
+    app.kubernetes.io/name: ts-route-service
+    app.kubernetes.io/part-of: ts-route
+    app.kubernetes.io/component: web
 spec:
   ports:
     - name: http
       port: 11178
   selector:
-    app: ts-route-service
+    app.kubernetes.io/name: ts-route-service
+    app.kubernetes.io/part-of: ts-route
+    app.kubernetes.io/component: web
 
 ---
 
@@ -2193,12 +2641,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-seat-service
+  labels:
+    app.kubernetes.io/name: ts-seat-service
+    app.kubernetes.io/part-of: ts-seat
+    app.kubernetes.io/component: web
 spec:
   ports:
     - name: http
       port: 18898
   selector:
-    app: ts-seat-service
+    app.kubernetes.io/name: ts-seat-service
+    app.kubernetes.io/part-of: ts-seat
+    app.kubernetes.io/component: web
 
 ---
 
@@ -2206,12 +2660,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-security-service
+  labels:
+    app.kubernetes.io/name: ts-security-service
+    app.kubernetes.io/part-of: ts-security
+    app.kubernetes.io/component: web
 spec:
   ports:
     - name: http
       port: 11188
   selector:
-    app: ts-security-service
+    app.kubernetes.io/name: ts-security-service
+    app.kubernetes.io/part-of: ts-security
+    app.kubernetes.io/component: web
 
 ---
 
@@ -2219,13 +2679,19 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-auth-service
+  labels:
+    app.kubernetes.io/name: ts-auth-service
+    app.kubernetes.io/part-of: ts-auth
+    app.kubernetes.io/component: web
 spec:
   type: LoadBalancer
   ports:
     - name: http
       port: 12340
   selector:
-    app: ts-auth-service
+    app.kubernetes.io/name: ts-auth-service
+    app.kubernetes.io/part-of: ts-auth
+    app.kubernetes.io/component: web
 
 ---
 
@@ -2233,12 +2699,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-station-service
+  labels:
+    app.kubernetes.io/name: ts-station-service
+    app.kubernetes.io/part-of: ts-station
+    app.kubernetes.io/component: web
 spec:
   ports:
     - name: http
       port: 12345
   selector:
-    app: ts-station-service
+    app.kubernetes.io/name: ts-station-service
+    app.kubernetes.io/part-of: ts-station
+    app.kubernetes.io/component: web
 
 ---
 
@@ -2246,12 +2718,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-ticket-office-service
+  labels:
+    app.kubernetes.io/name: ts-ticket-office-service
+    app.kubernetes.io/part-of: ts-ticket-office
+    app.kubernetes.io/component: web
 spec:
   ports:
     - name: http
       port: 16108
   selector:
-    app: ts-ticket-office-service
+    app.kubernetes.io/name: ts-ticket-office-service
+    app.kubernetes.io/part-of: ts-ticket-office
+    app.kubernetes.io/component: web
 
 ---
 
@@ -2259,12 +2737,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-ticketinfo-service
+  labels:
+    app.kubernetes.io/name: ts-ticketinfo-service
+    app.kubernetes.io/part-of: ts-ticketinfo
+    app.kubernetes.io/component: web
 spec:
   ports:
     - name: http
       port: 15681
   selector:
-    app: ts-ticketinfo-service
+    app.kubernetes.io/name: ts-ticketinfo-service
+    app.kubernetes.io/part-of: ts-ticketinfo
+    app.kubernetes.io/component: web
 
 ---
 
@@ -2272,12 +2756,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-train-service
+  labels:
+    app.kubernetes.io/name: ts-train-service
+    app.kubernetes.io/part-of: ts-train
+    app.kubernetes.io/component: web
 spec:
   ports:
     - name: http
       port: 14567
   selector:
-    app: ts-train-service
+    app.kubernetes.io/name: ts-train-service
+    app.kubernetes.io/part-of: ts-train
+    app.kubernetes.io/component: web
 
 ---
 
@@ -2285,12 +2775,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-travel2-service
+  labels:
+    app.kubernetes.io/name: ts-travel2-service
+    app.kubernetes.io/part-of: ts-travel2
+    app.kubernetes.io/component: web
 spec:
   ports:
     - name: http
       port: 16346
   selector:
-    app: ts-travel2-service
+    app.kubernetes.io/name: ts-travel2-service
+    app.kubernetes.io/part-of: ts-travel2
+    app.kubernetes.io/component: web
 
 ---
 
@@ -2298,12 +2794,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-travel-plan-service
+  labels:
+    app.kubernetes.io/name: ts-travel-plan-service
+    app.kubernetes.io/part-of: ts-travel-plan
+    app.kubernetes.io/component: web
 spec:
   ports:
     - name: http
       port: 14322
   selector:
-    app: ts-travel-plan-service
+    app.kubernetes.io/name: ts-travel-plan-service
+    app.kubernetes.io/part-of: ts-travel-plan
+    app.kubernetes.io/component: web
 
 ---
 
@@ -2311,12 +2813,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-travel-service
+  labels:
+    app.kubernetes.io/name: ts-travel-service
+    app.kubernetes.io/part-of: ts-travel
+    app.kubernetes.io/component: web
 spec:
   ports:
     - name: http
       port: 12346
   selector:
-    app: ts-travel-service
+    app.kubernetes.io/name: ts-travel-service
+    app.kubernetes.io/part-of: ts-travel
+    app.kubernetes.io/component: web
 
 
 ---
@@ -2325,12 +2833,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-verification-code-service
+  labels:
+    app.kubernetes.io/name: ts-verification-code-service
+    app.kubernetes.io/part-of: ts-verification-code
+    app.kubernetes.io/component: web
 spec:
   ports:
     - name: http
       port: 15678
   selector:
-    app: ts-verification-code-service
+    app.kubernetes.io/name: ts-verification-code-service
+    app.kubernetes.io/part-of: ts-verification-code
+    app.kubernetes.io/component: web
 
 
 ---
@@ -2339,9 +2853,15 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-voucher-service
+  labels:
+    app.kubernetes.io/name: ts-voucher-service
+    app.kubernetes.io/part-of: ts-voucher
+    app.kubernetes.io/component: web
 spec:
   ports:
     - name: http
       port: 16101
   selector:
-    app: ts-voucher-service
+    app.kubernetes.io/name: ts-voucher-service
+    app.kubernetes.io/part-of: ts-voucher
+    app.kubernetes.io/component: web

--- a/manifests/train-ticket-base/app/ts-part3.yaml
+++ b/manifests/train-ticket-base/app/ts-part3.yaml
@@ -2,15 +2,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ts-ui-dashboard
+  labels:
+    app.kubernetes.io/name: ts-ui-dashboard
+    app.kubernetes.io/component: proxy
 spec:
   selector:
     matchLabels:
-      app: ts-ui-dashboard
+      app.kubernetes.io/name: ts-ui-dashboard
+      app.kubernetes.io/component: proxy
   replicas: 1
   template:
     metadata:
       labels:
-        app: ts-ui-dashboard
+        app.kubernetes.io/name: ts-ui-dashboard
+        app.kubernetes.io/component: proxy
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "4040"
@@ -55,6 +60,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ts-ui-dashboard
+  labels:
+    app.kubernetes.io/name: ts-ui-dashboard
+    app.kubernetes.io/component: proxy
 spec:
   type: NodePort
   ports:
@@ -62,5 +70,6 @@ spec:
       port: 8080
       nodePort: 32677
   selector:
-    app: ts-ui-dashboard
+    app.kubernetes.io/name: ts-ui-dashboard
+    app.kubernetes.io/component: proxy
 ---

--- a/manifests/train-ticket-base/kustomization.yaml
+++ b/manifests/train-ticket-base/kustomization.yaml
@@ -2,3 +2,4 @@ resources:
 - monitoring
 - app
 - loadtest
+- litmus

--- a/manifests/train-ticket-base/litmus/argo-access.yaml
+++ b/manifests/train-ticket-base/litmus/argo-access.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: argo-chaos
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: chaos-cluster-role
+rules:
+- apiGroups: ['*']
+  resources: ['*']
+  verbs: ['*']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: chaos-cluster-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chaos-cluster-role
+subjects:
+- kind: ServiceAccount
+  name: argo-chaos

--- a/manifests/train-ticket-base/litmus/kustomization.yaml
+++ b/manifests/train-ticket-base/litmus/kustomization.yaml
@@ -1,0 +1,4 @@
+namespace: litmus
+resources:
+- ./litmus-ns.yaml
+- ./argo-access.yaml

--- a/manifests/train-ticket-base/litmus/litmus-ns.yaml
+++ b/manifests/train-ticket-base/litmus/litmus-ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: litmus

--- a/manifests/train-ticket-base/loadtest/kustomization.yaml
+++ b/manifests/train-ticket-base/loadtest/kustomization.yaml
@@ -1,6 +1,7 @@
 namespace: loadtest
 resources:
 - loadtest-ns.yaml
+- loadtest-svc.yaml
 - loadtest-dep.yaml
 
 configMapGenerator:

--- a/manifests/train-ticket-base/loadtest/loadtest-dep.yaml
+++ b/manifests/train-ticket-base/loadtest/loadtest-dep.yaml
@@ -1,34 +1,88 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: load-test
+  name: load-test-master
   labels:
-    name: load-test
-  namespace: loadtest
+    app.kubernetes.io/name: load-test-master
+    app.kubernetes.io/parts-of: load-test-cluster
+    app.kubernetes.io/component: locust-master
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
-      name: load-test
+      app.kubernetes.io/name: load-test-master
+      app.kubernetes.io/parts-of: load-test-cluster
+      app.kubernetes.io/component: locust-master
   template:
     metadata:
       labels:
-        name: load-test
+        app.kubernetes.io/name: load-test-master
+        app.kubernetes.io/parts-of: load-test-cluster
+        app.kubernetes.io/component: locust-master
     spec:
       containers:
-      - name: load-test
+      - name: load-test-master
         image: locustio/locust:2.9.0
-        command: ["/bin/sh"]
-        # locust log: 'Your selected spawn rate is very high (>100), and this is known to sometimes cause issues. Do you really need to ramp up that fast?'
-        args: ["-c", "while true; do locust --host http://ts-ui-dashboard.train-ticket.svc.cluster.local:8080 -f /config/locustfile.py --headless --users $(LOCUST_USERS) --spawn-rate $(LOCUST_SPAWN_RATE) --run-time 30s --only-summary; done"]
+        args: ["-f", "/config/locustfile.py", "--master"]
         volumeMounts:
           - name: locustfile-volume
             mountPath: /config
         env:
+          - name: LOCUST_HOST
+            value: 'http://ts-ui-dashboard.train-ticket.svc.cluster.local:8080'
           - name: LOCUST_USERS
             value: '5'
           - name: LOCUST_SPAWN_RATE
             value: '5'
+          - name: LOCUST_AUTOSTART
+            value: '1'
+        ports:
+          - name: master-web
+            containerPort: 8089
+            protocol: TCP
+          - name: master-p1
+            containerPort: 5557
+            protocol: TCP
+      volumes:
+        - name: locustfile-volume
+          configMap:
+            name: locustfile
+      nodeSelector:
+        kubernetes.io/os: linux
+        cloud.google.com/gke-nodepool: "load-pool"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: load-test-worker
+  labels:
+    app.kubernetes.io/name: load-test-worker
+    app.kubernetes.io/parts-of: load-test-cluster
+    app.kubernetes.io/component: locust-worker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: load-test-worker
+      app.kubernetes.io/parts-of: load-test-cluster
+      app.kubernetes.io/component: locust-worker
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: load-test-worker
+        app.kubernetes.io/parts-of: load-test-cluster
+        app.kubernetes.io/component: locust-worker
+    spec:
+      containers:
+      - name: load-test-worker
+        image: locustio/locust:2.9.0
+        args: ["-f", "/config/locustfile.py", "--worker"]
+        volumeMounts:
+          - name: locustfile-volume
+            mountPath: /config
+        env:
+          - name: LOCUST_MASTER_NODE_HOST
+            value: 'load-test-master.loadtest.svc.cluster.local'
       volumes:
         - name: locustfile-volume
           configMap:

--- a/manifests/train-ticket-base/loadtest/loadtest-dep.yaml
+++ b/manifests/train-ticket-base/loadtest/loadtest-dep.yaml
@@ -3,6 +3,7 @@ kind: Deployment
 metadata:
   name: load-test-master
   labels:
+    app: load-test-master
     app.kubernetes.io/name: load-test-master
     app.kubernetes.io/parts-of: load-test-cluster
     app.kubernetes.io/component: locust-master
@@ -10,12 +11,14 @@ spec:
   replicas: 1
   selector:
     matchLabels:
+      app: load-test-master
       app.kubernetes.io/name: load-test-master
       app.kubernetes.io/parts-of: load-test-cluster
       app.kubernetes.io/component: locust-master
   template:
     metadata:
       labels:
+        app: load-test-master
         app.kubernetes.io/name: load-test-master
         app.kubernetes.io/parts-of: load-test-cluster
         app.kubernetes.io/component: locust-master
@@ -35,7 +38,7 @@ spec:
           - name: LOCUST_SPAWN_RATE
             value: '5'
           - name: LOCUST_AUTOSTART
-            value: '1'
+            value: 'true'
         ports:
           - name: master-web
             containerPort: 8089
@@ -56,6 +59,7 @@ kind: Deployment
 metadata:
   name: load-test-worker
   labels:
+    app: load-test-worker
     app.kubernetes.io/name: load-test-worker
     app.kubernetes.io/parts-of: load-test-cluster
     app.kubernetes.io/component: locust-worker
@@ -63,12 +67,14 @@ spec:
   replicas: 1
   selector:
     matchLabels:
+      app: load-test-worker
       app.kubernetes.io/name: load-test-worker
       app.kubernetes.io/parts-of: load-test-cluster
       app.kubernetes.io/component: locust-worker
   template:
     metadata:
       labels:
+        app: load-test-worker
         app.kubernetes.io/name: load-test-worker
         app.kubernetes.io/parts-of: load-test-cluster
         app.kubernetes.io/component: locust-worker

--- a/manifests/train-ticket-base/loadtest/loadtest-svc.yaml
+++ b/manifests/train-ticket-base/loadtest/loadtest-svc.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: load-test-master
+  labels:
+    app.kubernetes.io/name: load-test-master
+    app.kubernetes.io/parts-of: load-test-cluster
+    app.kubernetes.io/component: locust-master
+spec:
+  ports:
+  - name: master-web
+    nodePort: 30060
+    port: 8089
+    protocol: TCP
+    targetPort: master-web
+  - name: master-p1
+    nodePort: 30061
+    port: 5557
+    protocol: TCP
+    targetPort: master-p1
+  type: NodePort
+  selector:
+    app.kubernetes.io/name: load-test-master
+    app.kubernetes.io/parts-of: load-test-cluster
+    app.kubernetes.io/component: locust-master

--- a/manifests/train-ticket-base/loadtest/loadtest-svc.yaml
+++ b/manifests/train-ticket-base/loadtest/loadtest-svc.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   name: load-test-master
   labels:
+    app: load-test-master
     app.kubernetes.io/name: load-test-master
     app.kubernetes.io/parts-of: load-test-cluster
     app.kubernetes.io/component: locust-master
@@ -20,6 +21,7 @@ spec:
     targetPort: master-p1
   type: NodePort
   selector:
+    app: load-test-master
     app.kubernetes.io/name: load-test-master
     app.kubernetes.io/parts-of: load-test-cluster
     app.kubernetes.io/component: locust-master

--- a/manifests/train-ticket-base/loadtest/locustfile.py
+++ b/manifests/train-ticket-base/loadtest/locustfile.py
@@ -75,8 +75,13 @@ def login(client):
 
     def api_call_admin_create_user():
         headers = {"Authorization": f"Bearer {token}", "Accept": "application/json", "Content-Type": "application/json"}
-        body = {"documentNum": None, "documentType": 0, "email": "string", "gender": 0, "password": password, "userName": user_name}
-        response = client.post(url="/api/v1/adminuserservice/users", headers=headers, json=body, name=get_name_suffix("admin_create_user"))
+        body = {
+            "documentNum": None, "documentType": 0, "email": "string", "gender": 0,
+            "password": password, "userName": user_name,
+        }
+        response = client.post(
+            url="/api/v1/adminuserservice/users", headers=headers, json=body,
+            name=get_name_suffix("admin_create_user"))
         return response_as_json, response_as_json["status"]
 
     response_as_json = try_until_success(api_call_admin_create_user)
@@ -95,8 +100,13 @@ def login(client):
 
     def api_call_create_contact_for_user():
         headers = {"Authorization": f"Bearer {token}", "Accept": "application/json", "Content-Type": "application/json"}
-        body = {"name": user_name, "accountId": user_id, "documentType": "1", "documentNumber": "123456", "phoneNumber": "123456"}
-        response = client.post(url="/api/v1/contactservice/contacts", headers=headers, json=body, name=get_name_suffix("admin_create_contact"))
+        body = {
+            "name": user_name, "accountId": user_id, "documentType": "1",
+            "documentNumber": "123456", "phoneNumber": "123456",
+        }
+        response = client.post(
+            url="/api/v1/contactservice/contacts", headers=headers, json=body,
+            name=get_name_suffix("admin_create_contact"))
         return response_as_json, response_as_json["status"]
 
     try_until_success(api_call_create_contact_for_user)
@@ -142,7 +152,9 @@ def get_trip_information(client, from_station, to_station):
 
     def api_call_get_trip_information():
         body = {"startingPlace": from_station, "endPlace": to_station, "departureTime": departure_date}
-        response = client.post(url="/api/v1/travelservice/trips/left", json=body, catch_response=True, name=get_name_suffix("get_trip_information"))
+        response = client.post(
+            url="/api/v1/travelservice/trips/left", json=body, catch_response=True,
+            name=get_name_suffix("get_trip_information"))
         response_as_json = get_json_from_response(response)
         return response_as_json, response_as_json["status"]
 
@@ -164,17 +176,23 @@ def book(client, user_id):
     departure_date = next_monday.strftime("%Y-%m-%d")
 
     def api_call_insurance():
-        response = client.get(url="/api/v1/assuranceservice/assurances/types", name=get_name_suffix("get_assurance_types"))
+        response = client.get(
+            url="/api/v1/assuranceservice/assurances/types",
+            name=get_name_suffix("get_assurance_types"))
         response_as_json = get_json_from_response(response)
         return response_as_json, response_as_json["status"]
 
     def api_call_food():
-        response = client.get(url=f"/api/v1/foodservice/foods/{departure_date}/Shang%20Hai/Su%20Zhou/D1345", name=get_name_suffix("get_food_types"))
+        response = client.get(
+            url=f"/api/v1/foodservice/foods/{departure_date}/Shang%20Hai/Su%20Zhou/D1345",
+            name=get_name_suffix("get_food_types"))
         response_as_json = get_json_from_response(response)
         return response_as_json, response_as_json["status"]
 
     def api_call_contacts():
-        response = client.get(url=f"/api/v1/contactservice/contacts/account/{user_id}", name=get_name_suffix("query_contacts"))
+        response = client.get(
+            url=f"/api/v1/contactservice/contacts/account/{user_id}",
+            name=get_name_suffix("query_contacts"))
         response_as_json = get_json_from_response(response)
         return response_as_json, response_as_json["status"]
 
@@ -185,8 +203,14 @@ def book(client, user_id):
     contact_id = data[0]["id"]
 
     def api_call_ticket():
-        body = {"accountId": user_id, "contactsId": contact_id, "tripId": "D1345", "seatType": "2", "date": departure_date, "from": "Shang Hai", "to": "Su Zhou", "assurance": "0", "foodType": 1, "foodName": "Bone Soup", "foodPrice": 2.5, "stationName": "", "storeName": ""}
-        response = client.post(url="/api/v1/preserveservice/preserve", json=body, catch_response=True, name=get_name_suffix("preserve_ticket"))
+        body = {
+            "accountId": user_id, "contactsId": contact_id, "tripId": "D1345", "seatType": "2",
+            "date": departure_date, "from": "Shang Hai", "to": "Su Zhou", "assurance": "0",
+            "foodType": 1, "foodName": "Bone Soup", "foodPrice": 2.5, "stationName": "", "storeName": "",
+        }
+        response = client.post(
+            url="/api/v1/preserveservice/preserve", json=body, catch_response=True,
+            name=get_name_suffix("preserve_ticket"))
         response_as_json = get_json_from_response(response)
         return response_as_json, response_as_json["status"]
 
@@ -195,8 +219,13 @@ def book(client, user_id):
 
 def get_last_order(client, user_id, expected_status):
     def api_call_query():
-        body = {"loginId": user_id, "enableStateQuery": "false", "enableTravelDateQuery": "false", "enableBoughtDateQuery": "false", "travelDateStart": "null", "travelDateEnd": "null", "boughtDateStart": "null", "boughtDateEnd": "null"}
-        response = client.post(url="/api/v1/orderservice/order/refresh", json=body, name=get_name_suffix("get_order_information"))
+        body = {
+            "loginId": user_id, "enableStateQuery": "false", "enableTravelDateQuery": "false",
+            "enableBoughtDateQuery": "false", "travelDateStart": "null", "travelDateEnd": "null",
+            "boughtDateStart": "null", "boughtDateEnd": "null",
+        }
+        response = client.post(
+            url="/api/v1/orderservice/order/refresh", json=body, name=get_name_suffix("get_order_information"))
         response_as_json = get_json_from_response(response)
         return response_as_json, response_as_json["status"]
 
@@ -213,7 +242,7 @@ def get_last_order(client, user_id, expected_status):
 def get_last_order_id(client, user_id, expected_status):
     order = get_last_order(client, user_id, expected_status)
 
-    if order!=None:
+    if order is not None:
         order_id = order["id"]
         return order_id
 
@@ -222,12 +251,13 @@ def get_last_order_id(client, user_id, expected_status):
 
 def pay(client, user_id):
     order_id = get_last_order_id(client, user_id, STATUS_BOOKED)
-    if order_id == None:
+    if order_id is None:
         raise Exception("Weird... There is no order to pay.")
 
     def api_call_pay():
         body = {"orderId": order_id, "tripId": "D1345"}
-        response = client.post(url="/api/v1/inside_pay_service/inside_payment", json=body, name=get_name_suffix("pay_order"))
+        response = client.post(
+            url="/api/v1/inside_pay_service/inside_payment", json=body, name=get_name_suffix("pay_order"))
         response_as_json = get_json_from_response(response)
         return response_as_json, response_as_json["status"]
 
@@ -236,11 +266,12 @@ def pay(client, user_id):
 
 def cancel(client, user_id):
     order_id = get_last_order_id(client, user_id, STATUS_BOOKED)
-    if order_id == None:
+    if order_id is None:
         raise Exception("Weird... There is no order to cancel.")
 
     def api_call_cancel():
-        response = client.get(url=f"/api/v1/cancelservice/cancel/{order_id}/{user_id}", name=get_name_suffix("cancel_order"))
+        response = client.get(
+            url=f"/api/v1/cancelservice/cancel/{order_id}/{user_id}", name=get_name_suffix("cancel_order"))
         response_as_json = get_json_from_response(response)
         return response_as_json, response_as_json["status"]
 
@@ -250,12 +281,16 @@ def cancel(client, user_id):
 def consign(client, user_id):
     departure_date = get_departure_date()
     order_id = get_last_order_id(client, user_id, STATUS_BOOKED)
-    if order_id == None:
+    if order_id is None:
         raise Exception("Weird... There is no order to consign.")
 
     def api_call_consign():
-        body={"accountId": user_id, "handleDate": departure_date, "from": "Shang Hai", "to": "Su Zhou", "orderId": order_id, "consignee": order_id, "phone": "123", "weight": "1", "id": "", "isWithin": "false"}
-        response = client.put(url="/api/v1/consignservice/consigns", json=body, name=get_name_suffix("create_consign"))
+        body = {
+            "accountId": user_id, "handleDate": departure_date, "from": "Shang Hai", "to": "Su Zhou",
+            "orderId": order_id, "consignee": order_id, "phone": "123", "weight": "1", "id": "", "isWithin": "false",
+        }
+        response = client.put(
+            url="/api/v1/consignservice/consigns", json=body, name=get_name_suffix("create_consign"))
         response_as_json = get_json_from_response(response)
         return response_as_json, response_as_json["status"]
 
@@ -264,22 +299,24 @@ def consign(client, user_id):
 
 def collect_and_use(client, user_id):
     order_id = get_last_order_id(client, user_id, STATUS_PAID)
-    if order_id == None:
+    if order_id is None:
         raise Exception("Weird... There is no order to collect.")
 
     def api_call_collect_ticket():
-        response = client.get(url=f"/api/v1/executeservice/execute/collected/{order_id}", name=get_name_suffix("collect_ticket"))
+        response = client.get(
+            url=f"/api/v1/executeservice/execute/collected/{order_id}", name=get_name_suffix("collect_ticket"))
         response_as_json = get_json_from_response(response)
         return response_as_json, response_as_json["status"]
 
     try_until_success(api_call_collect_ticket)
 
     order_id = get_last_order_id(client, user_id, STATUS_COLLECTED)
-    if order_id == None:
+    if order_id is None:
         raise Exception("Weird... There is no order to execute.")
 
     def api_call_enter_station():
-        response = client.get(url=f"/api/v1/executeservice/execute/execute/{order_id}", name=get_name_suffix("enter_station"))
+        response = client.get(
+            url=f"/api/v1/executeservice/execute/execute/{order_id}", name=get_name_suffix("enter_station"))
         response_as_json = get_json_from_response(response)
         return response_as_json, response_as_json["status"]
 
@@ -288,12 +325,12 @@ def collect_and_use(client, user_id):
 
 def get_voucher(client, user_id):
     order_id = get_last_order_id(client, user_id, STATUS_EXECUTED)
-    if order_id == None:
+    if order_id is None:
         raise Exception("Weird... There is no order that was used.")
 
     def api_call_get_voucher():
         body = {"orderId": order_id, "type": 1}
-        response = client.post(url=f"/getVoucher", json=body, name=get_name_suffix("get_voucher"))
+        response = client.post(url="/getVoucher", json=body, name=get_name_suffix("get_voucher"))
         response_as_json = get_json_from_response(response)
         return response_as_json, response_as_json["status"]
 

--- a/manifests/train-ticket-base/loadtest/locustfile.py
+++ b/manifests/train-ticket-base/loadtest/locustfile.py
@@ -82,6 +82,7 @@ def login(client):
         response = client.post(
             url="/api/v1/adminuserservice/users", headers=headers, json=body,
             name=get_name_suffix("admin_create_user"))
+        response_as_json = get_json_from_response(response)
         return response_as_json, response_as_json["status"]
 
     response_as_json = try_until_success(api_call_admin_create_user)
@@ -107,6 +108,7 @@ def login(client):
         response = client.post(
             url="/api/v1/contactservice/contacts", headers=headers, json=body,
             name=get_name_suffix("admin_create_contact"))
+        response_as_json = get_json_from_response(response)
         return response_as_json, response_as_json["status"]
 
     try_until_success(api_call_create_contact_for_user)

--- a/manifests/train-ticket-base/monitoring/prometheus.config.yaml
+++ b/manifests/train-ticket-base/monitoring/prometheus.config.yaml
@@ -58,10 +58,13 @@ scrape_configs:
     regex: __meta_kubernetes_node_label_cloud_google_com_gke_nodepool
     replacement: nodepool
   metric_relabel_configs:
-  - source_labels: ['pod', 'pod_name']
-    regex: '^(ts-[a-zA-Z\d]+-[a-zA-Z\d]+)-.+$'  # eg. "ts-notification-service-bcd6b59dc-7qwch"
+  - source_labels: [pod_name]
+    action: replace
+    target_label: pod
+  - source_labels: [pod]
+    regex: '^([a-zA-Z0-9-]+)?-([0-9a-f]{7,10})?-([a-z0-9]{5}|\d+)$'  # eg. "ts-notification-service-bcd6b59dc-7qwch"
     replacement: ${1}
-    target_label: app
+    target_label: pod_group
 
 - job_name: 'kubernetes-services'
   kubernetes_sd_configs:

--- a/manifests/train-ticket-overlays/single-replica/loadtest.yaml
+++ b/manifests/train-ticket-overlays/single-replica/loadtest.yaml
@@ -13,6 +13,6 @@ spec:
       - name: load-test-master
         env:
           - name: LOCUST_USERS
-            value: '50'
+            value: '100'
           - name: LOCUST_SPAWN_RATE
             value: '1'

--- a/manifests/train-ticket-overlays/single-replica/loadtest.yaml
+++ b/manifests/train-ticket-overlays/single-replica/loadtest.yaml
@@ -1,17 +1,18 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: load-test
+  name: load-test-master
   labels:
-    name: load-test
-  namespace: loadtest
+    app.kubernetes.io/name: load-test-master
+    app.kubernetes.io/parts-of: load-test-cluster
+    app.kubernetes.io/component: locust-master
 spec:
   template:
     spec:
       containers:
-      - name: load-test
+      - name: load-test-master
         env:
           - name: LOCUST_USERS
-            value: '500'
+            value: '50'
           - name: LOCUST_SPAWN_RATE
             value: '1'

--- a/workflows/argowf-chaos.cue
+++ b/workflows/argowf-chaos.cue
@@ -265,6 +265,8 @@ spec: {
 		container: {
 			image: "ghcr.io/ai4sre/meltria/collectors-metrics:latest"
 			imagePullPolicy: "Always"
+			// `command must be specified for containers.` https://argoproj.github.io/argo-workflows/workflow-executors/#emissary-emissary
+			command: ["/usr/src/app/bin/get_metrics_from_prom.py"],
 			args: [
 				"--prometheus-url",
 				"http://prometheus.monitoring.svc.cluster.local:9090",
@@ -327,7 +329,7 @@ spec: {
 						engineState:     "active"
 						appinfo: {
 							appns: "{{workflow.parameters.appNamespace}}"
-							applabel: "name={{inputs.parameters.appLabel}}"
+							applabel: "app.kubernetes.io/name={{inputs.parameters.appLabel}}"
 							appkind:  "deployment"
 						}
 						chaosServiceAccount: "{{workflow.parameters.chaosServiceAccount}}"

--- a/workflows/argowf-chaos.cue
+++ b/workflows/argowf-chaos.cue
@@ -34,6 +34,12 @@ import "strings"
 		name: "pod-cpu-hog"
 		spec: {
 			components: env: [{
+				name: "CONTAINER_RUNTIME"
+				value: "containerd"
+			}, {
+				name: "SOCKET_PATH"
+				value: "/var/run/containerd/containerd.sock"
+			}, {
 				name:  "TARGET_CONTAINER"
 				value: "{{inputs.parameters.appLabel}}"
 			}, {
@@ -49,6 +55,12 @@ import "strings"
 		name: "pod-memory-hog"
 		spec: {
 			components: env: [{
+				name: "CONTAINER_RUNTIME"
+				value: "containerd"
+			}, {
+				name: "SOCKET_PATH"
+				value: "/var/run/containerd/containerd.sock"
+			}, {
 				name:  "TARGET_CONTAINER"
 				value: "{{inputs.parameters.appLabel}}"
 			}, {
@@ -64,6 +76,12 @@ import "strings"
 		name: "pod-network-loss"
 		spec: {
 			components: env: [{
+				name: "CONTAINER_RUNTIME"
+				value: "containerd"
+			}, {
+				name: "SOCKET_PATH"
+				value: "/var/run/containerd/containerd.sock"
+			}, {
 				name:  "TARGET_CONTAINER"
 				value: "{{inputs.parameters.appLabel}}"
 			}, {
@@ -82,6 +100,12 @@ import "strings"
 		name: "pod-network-latency"
 		spec: {
 			components: env: [{
+				name: "CONTAINER_RUNTIME"
+				value: "containerd"
+			}, {
+				name: "SOCKET_PATH"
+				value: "/var/run/containerd/containerd.sock"
+			}, {
 				name:  "TARGET_CONTAINER"
 				value: "{{inputs.parameters.appLabel}}"
 			}, {

--- a/workflows/argowf-chaos.cue
+++ b/workflows/argowf-chaos.cue
@@ -292,10 +292,9 @@ spec: {
 			// `command must be specified for containers.` https://argoproj.github.io/argo-workflows/workflow-executors/#emissary-emissary
 			command: ["/usr/src/app/bin/get_metrics_from_prom.py"],
 			args: [
-				"--prometheus-url",
-				"http://prometheus.monitoring.svc.cluster.local:9090",
-				"--grafana-url",
-				"http://grafana.monitoring.svc.cluster.local:3000",
+				"--target", "{{workflow.parameters.appNamespace}}",
+				"--prometheus-url", "http://prometheus.monitoring.svc.cluster.local:9090",
+				"--grafana-url", "http://grafana.monitoring.svc.cluster.local:3000",
 				"--end", "{{inputs.parameters.endTimestamp}}",
 				"--chaos-injected-component", "{{inputs.parameters.appLabel}}",
 				"--injected-chaos-type", "{{inputs.parameters.chaosType}}",

--- a/workflows/run-one-chaos
+++ b/workflows/run-one-chaos
@@ -8,7 +8,7 @@ chaos=$3
 debug=$4
 
 cleanup='delete'
-if [[ debug != "" ]]; then
+if [[ ${debug} != "" ]]; then
   cleanup='retain'
 fi
 

--- a/workflows/run-one-chaos
+++ b/workflows/run-one-chaos
@@ -2,13 +2,14 @@
 
 set -e -o pipefail
 
-appLabel=$1
-chaos=$2
-debug=$3
+appNamespace=$1
+appLabel=$2
+chaos=$3
+debug=$4
 
 cleanup='delete'
 if [[ debug != "" ]]; then
   cleanup='retain'
 fi
 
-cue eval --out yaml argowf-chaos.cue | argo submit -n litmus --watch --parameter chaosTypes="'$2'" --parameter appLabels="[\"$1\"]" --parameter litmusJobCleanupPolicy="${cleanup}" -
+cue eval --out yaml argowf-chaos.cue | argo submit -n litmus --watch --parameter appNamespace="${appNamespace}" --parameter chaosTypes="'${chaos}'" --parameter appLabels="[\"${appLabel}\"]" --parameter litmusJobCleanupPolicy="${cleanup}" -


### PR DESCRIPTION
- manifests: setup litmus for train ticket
- workflows: add appNamespace param to run-one-chaos
- manifests: enrich labels of the resources of the trainticket
- workflows: fix debug option
- collectors/metrics: fix app into app_kubernetes_io_name
- workflows: fix an issue where an chaos could not been injected
- workflows: set CONTAINER_RUNTIME to containerd
- manifests: enrich labels of the resources of the sockshop
- manifests: generate pod_group label for prometheus
- collectors/metrics: fix --target arg name
- manifests: increate JVM memory size of ts-travel2-service
- manifests: fix mislabeled app.kubernetes.io/part-of
