### PR TITLE
diagnose trainticket performance issues

### DIFF
--- a/manifests/train-ticket-base/app/jmx-exporter.config.yaml
+++ b/manifests/train-ticket-base/app/jmx-exporter.config.yaml
@@ -5,3 +5,5 @@ password:
 
 rules:
 - pattern: ".*"
+
+cache: true

--- a/manifests/train-ticket-base/app/patch-jmx-exporter.yaml
+++ b/manifests/train-ticket-base/app/patch-jmx-exporter.yaml
@@ -25,8 +25,8 @@ spec:
               cpu: 50m
               memory: 100Mi
             limits:
-              cpu: 50m
-              memory: 100Mi
+              cpu: 100m
+              memory: 200Mi
       volumes:
         - name: configmap-jmx
           configMap:

--- a/manifests/train-ticket-base/app/ts-part1.yaml
+++ b/manifests/train-ticket-base/app/ts-part1.yaml
@@ -768,6 +768,40 @@ spec:
           requests:
             cpu: 50m
             memory: 100Mi
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ts-notification-mongo
+  labels:
+    app.kubernetes.io/name: ts-notification-mongo
+    app.kubernetes.io/part-of: ts-notification
+    app.kubernetes.io/component: db
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ts-notification-mongo
+      app.kubernetes.io/part-of: ts-notification
+      app.kubernetes.io/component: db
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ts-notification-mongo
+        app.kubernetes.io/part-of: ts-notification
+        app.kubernetes.io/component: db
+    spec:
+      containers:
+        - name: ts-notification-mongo
+          image: mongo
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 27017
+          resources:
+            requests:
+              cpu: 50m
+              memory: 100Mi
 
 ---
 apiVersion: v1
@@ -1161,3 +1195,22 @@ spec:
     app.kubernetes.io/name: ts-food-mongo
     app.kubernetes.io/part-of: ts-food
     app.kubernetes.io/component: db
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ts-notification-mongo
+  labels:
+    app.kubernetes.io/name: ts-notification-mongo
+    app.kubernetes.io/part-of: ts-notification
+    app.kubernetes.io/component: db
+spec:
+  ports:
+    - port: 27017
+  selector:
+    app.kubernetes.io/name: ts-notification-mongo
+    app.kubernetes.io/part-of: ts-notification
+    app.kubernetes.io/component: db
+
+---

--- a/manifests/train-ticket-base/app/ts-part2.yaml
+++ b/manifests/train-ticket-base/app/ts-part2.yaml
@@ -41,7 +41,7 @@ spec:
             cpu: 50m
             memory: 100Mi
           limits:
-            cpu: 100m
+            cpu: 200m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -95,7 +95,7 @@ spec:
             cpu: 50m
             memory: 160Mi
           limits:
-            cpu: 100m
+            cpu: 200m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -148,7 +148,7 @@ spec:
             cpu: 50m
             memory: 160Mi
           limits:
-            cpu: 100m
+            cpu: 200m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -201,7 +201,7 @@ spec:
             cpu: 50m
             memory: 160Mi
           limits:
-            cpu: 100m
+            cpu: 200m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -254,7 +254,7 @@ spec:
             cpu: 50m
             memory: 160Mi
           limits:
-            cpu: 150m
+            cpu: 200m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -307,7 +307,7 @@ spec:
             cpu: 50m
             memory: 160Mi
           limits:
-            cpu: 100m
+            cpu: 200m
             memory: 400Mi
         readinessProbe:
           tcpSocket:
@@ -360,7 +360,7 @@ spec:
             cpu: 50m
             memory: 160Mi
           limits:
-            cpu: 200m
+            cpu: 500m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -413,7 +413,7 @@ spec:
             cpu: 50m
             memory: 160Mi
           limits:
-            cpu: 100m
+            cpu: 200m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -463,10 +463,10 @@ spec:
         - containerPort: 15679
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 160Mi
           limits:
-            cpu: 100m
+            cpu: 500m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -519,7 +519,7 @@ spec:
             cpu: 50m
             memory: 160Mi
           limits:
-            cpu: 100m
+            cpu: 200m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -572,7 +572,7 @@ spec:
             cpu: 50m
             memory: 160Mi
           limits:
-            cpu: 100m
+            cpu: 200m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -622,10 +622,10 @@ spec:
         - containerPort: 12347
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 160Mi
           limits:
-            cpu: 100m
+            cpu: 500m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -678,7 +678,7 @@ spec:
             cpu: 50m
             memory: 160Mi
           limits:
-            cpu: 100m
+            cpu: 200m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -731,7 +731,7 @@ spec:
             cpu: 50m
             memory: 160Mi
           limits:
-            cpu: 100m
+            cpu: 200m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -837,7 +837,7 @@ spec:
             cpu: 50m
             memory: 160Mi
           limits:
-            cpu: 100m
+            cpu: 200m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -888,8 +888,8 @@ spec:
         - containerPort: 12340
         resources:
           requests:
-            cpu: 700m
-            memory: 800Mi
+            cpu: 500m
+            memory: 500Mi
           limits:
             cpu: 700m
             memory: 800Mi
@@ -937,7 +937,7 @@ spec:
             cpu: 50m
             memory: 50Mi
           limits:
-            cpu: 50m
+            cpu: 200m
             memory: 50Mi
         readinessProbe:
           tcpSocket:
@@ -990,7 +990,7 @@ spec:
             cpu: 50m
             memory: 160Mi
           limits:
-            cpu: 100m
+            cpu: 200m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -1522,7 +1522,7 @@ spec:
             memory: 160Mi
           limits:
             cpu: 200m
-            memory: 500Mi
+            memory: 700Mi
         readinessProbe:
           tcpSocket:
             port: 18898
@@ -1893,7 +1893,7 @@ spec:
             cpu: 100m
             memory: 200Mi
           limits:
-            cpu: 100m
+            cpu: 200m
             memory: 400Mi
         readinessProbe:
           tcpSocket:

--- a/manifests/train-ticket-base/app/ts-part2.yaml
+++ b/manifests/train-ticket-base/app/ts-part2.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: ts-admin-basic-info-service
-        image: codewisdom/ts-admin-basic-info-service-with-jaeger:v1
+        image: codewisdom/ts-admin-basic-info-service:0.2.0
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -79,7 +79,7 @@ spec:
     spec:
       containers:
       - name: ts-admin-order-service
-        image: codewisdom/ts-admin-order-service-with-jaeger:v1
+        image: codewisdom/ts-admin-order-service:0.2.0
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -132,7 +132,7 @@ spec:
     spec:
       containers:
       - name: ts-admin-route-service
-        image: codewisdom/ts-admin-route-service-with-jaeger:v1
+        image: codewisdom/ts-admin-route-service:0.2.0
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -185,7 +185,7 @@ spec:
     spec:
       containers:
       - name: ts-admin-travel-service
-        image: codewisdom/ts-admin-travel-service-with-jaeger:v1
+        image: codewisdom/ts-admin-travel-service:0.2.0
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -238,7 +238,7 @@ spec:
     spec:
       containers:
       - name: ts-admin-user-service
-        image: codewisdom/ts-admin-user-service-with-jaeger:v1
+        image: codewisdom/ts-admin-user-service:0.2.0
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -291,7 +291,7 @@ spec:
     spec:
       containers:
       - name: ts-assurance-service
-        image: codewisdom/ts-assurance-service-with-jaeger:v1
+        image: codewisdom/ts-assurance-service:0.2.0
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -344,7 +344,7 @@ spec:
     spec:
       containers:
       - name: ts-basic-service
-        image: codewisdom/ts-basic-service-with-jaeger:v1
+        image: codewisdom/ts-basic-service:0.2.0
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -397,7 +397,7 @@ spec:
     spec:
       containers:
       - name: ts-cancel-service
-        image: codewisdom/ts-cancel-service-with-jaeger:v1
+        image: codewisdom/ts-cancel-service:0.2.0
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -450,7 +450,7 @@ spec:
     spec:
       containers:
       - name: ts-config-service
-        image: codewisdom/ts-config-service-with-jaeger:v1
+        image: codewisdom/ts-config-service:0.2.0
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -503,7 +503,7 @@ spec:
     spec:
       containers:
       - name: ts-consign-price-service
-        image: codewisdom/ts-consign-price-service-with-jaeger:v1
+        image: codewisdom/ts-consign-price-service:0.2.0
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -556,7 +556,7 @@ spec:
     spec:
       containers:
       - name: ts-consign-service
-        image: codewisdom/ts-consign-service-with-jaeger:v1
+        image: codewisdom/ts-consign-service:0.2.0
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -609,7 +609,7 @@ spec:
     spec:
       containers:
       - name: ts-contacts-service
-        image: codewisdom/ts-contacts-service-with-jaeger:v1
+        image: codewisdom/ts-contacts-service:0.2.0
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -662,7 +662,7 @@ spec:
     spec:
       containers:
       - name: ts-execute-service
-        image: codewisdom/ts-execute-service-with-jaeger:v1
+        image: codewisdom/ts-execute-service:0.2.0
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -715,7 +715,7 @@ spec:
     spec:
       containers:
       - name: ts-food-map-service
-        image: codewisdom/ts-food-map-service-with-jaeger:v1
+        image: codewisdom/ts-food-map-service:0.2.0
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -768,7 +768,7 @@ spec:
     spec:
       containers:
       - name: ts-food-service
-        image: codewisdom/ts-food-service-with-jaeger:v1
+        image: codewisdom/ts-food-service:0.2.0
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -821,7 +821,7 @@ spec:
     spec:
       containers:
       - name: ts-inside-payment-service
-        image: codewisdom/ts-inside-payment-service-with-jaeger:v1
+        image: codewisdom/ts-inside-payment-service:0.2.0
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -874,7 +874,7 @@ spec:
     spec:
       containers:
       - name: ts-auth-service
-        image: codewisdom/ts-auth-service-with-jaeger:v1
+        image: codewisdom/ts-auth-service:0.2.0
         imagePullPolicy: IfNotPresent
         args: ["java", "-Xmx400m",  "-jar", "/app/ts-auth-service-1.0.jar"]
         env:
@@ -928,7 +928,7 @@ spec:
     spec:
       containers:
       - name: ts-news-service
-        image: codewisdom/ts-news-service-with-jaeger:v1
+        image: codewisdom/ts-news-service:0.2.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 12862
@@ -974,7 +974,7 @@ spec:
     spec:
       containers:
       - name: ts-notification-service
-        image: codewisdom/ts-notification-service-with-jaeger:v1
+        image: codewisdom/ts-notification-service:0.2.0
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -1027,7 +1027,7 @@ spec:
     spec:
       containers:
       - name: ts-order-other-service
-        image: codewisdom/ts-order-other-service-with-jaeger:v1
+        image: codewisdom/ts-order-other-service:0.2.0
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -1080,7 +1080,7 @@ spec:
     spec:
       containers:
       - name: ts-order-service
-        image: codewisdom/ts-order-service-with-jaeger:v1
+        image: codewisdom/ts-order-service:0.2.0
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -1133,7 +1133,7 @@ spec:
     spec:
       containers:
       - name: ts-payment-service
-        image: codewisdom/ts-payment-service-with-jaeger:v1
+        image: codewisdom/ts-payment-service:0.2.0
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -1186,7 +1186,7 @@ spec:
     spec:
       containers:
       - name: ts-preserve-other-service
-        image: codewisdom/ts-preserve-other-service-with-jaeger:v1
+        image: codewisdom/ts-preserve-other-service:0.2.0
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -1239,7 +1239,7 @@ spec:
     spec:
       containers:
       - name: ts-preserve-service
-        image: codewisdom/ts-preserve-service-with-jaeger:v1
+        image: codewisdom/ts-preserve-service:0.2.0
         imagePullPolicy: IfNotPresent
         args: ["java", "-Xmx400m",  "-jar", "/app/ts-preserve-service-1.0.jar"]
         env:
@@ -1293,7 +1293,7 @@ spec:
     spec:
       containers:
       - name: ts-price-service
-        image: codewisdom/ts-price-service-with-jaeger:v1
+        image: codewisdom/ts-price-service:0.2.0
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -1346,7 +1346,7 @@ spec:
     spec:
       containers:
       - name: ts-rebook-service
-        image: codewisdom/ts-rebook-service-with-jaeger:v1
+        image: codewisdom/ts-rebook-service:0.2.0
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -1399,7 +1399,7 @@ spec:
     spec:
       containers:
       - name: ts-route-plan-service
-        image: codewisdom/ts-route-plan-service-with-jaeger:v1
+        image: codewisdom/ts-route-plan-service:0.2.0
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -1452,7 +1452,7 @@ spec:
     spec:
       containers:
       - name: ts-route-service
-        image: codewisdom/ts-route-service-with-jaeger:v1
+        image: codewisdom/ts-route-service:0.2.0
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -1505,7 +1505,7 @@ spec:
     spec:
       containers:
       - name: ts-seat-service
-        image: codewisdom/ts-seat-service-with-jaeger:v1
+        image: codewisdom/ts-seat-service:0.2.0
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -1558,7 +1558,7 @@ spec:
     spec:
       containers:
       - name: ts-security-service
-        image: codewisdom/ts-security-service-with-jaeger:v1
+        image: codewisdom/ts-security-service:0.2.0
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -1611,7 +1611,7 @@ spec:
     spec:
       containers:
       - name: ts-user-service
-        image: codewisdom/ts-user-service-with-jaeger:v1
+        image: codewisdom/ts-user-service:0.2.0
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -1664,7 +1664,7 @@ spec:
     spec:
       containers:
       - name: ts-station-service
-        image: codewisdom/ts-station-service-with-jaeger:v1
+        image: codewisdom/ts-station-service:0.2.0
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -1717,7 +1717,7 @@ spec:
     spec:
       containers:
       - name: ts-ticket-office-service
-        image: codewisdom/ts-ticket-office-service-with-jaeger:v1
+        image: codewisdom/ts-ticket-office-service:0.2.0
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -1770,7 +1770,7 @@ spec:
     spec:
       containers:
       - name: ts-ticketinfo-service
-        image: codewisdom/ts-ticketinfo-service-with-jaeger:v1
+        image: codewisdom/ts-ticketinfo-service:0.2.0
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -1823,7 +1823,7 @@ spec:
     spec:
       containers:
       - name: ts-train-service
-        image: codewisdom/ts-train-service-with-jaeger:v1
+        image: codewisdom/ts-train-service:0.2.0
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -1876,7 +1876,7 @@ spec:
     spec:
       containers:
       - name: ts-travel2-service
-        image: codewisdom/ts-travel2-service-with-jaeger:v1
+        image: codewisdom/ts-travel2-service:0.2.0
         imagePullPolicy: IfNotPresent
         args: ["java", "-Xmx200m",  "-jar", "/app/ts-travel2-service-1.0.jar"]
         env:
@@ -1930,7 +1930,7 @@ spec:
     spec:
       containers:
       - name: ts-travel-plan-service
-        image: codewisdom/ts-travel-plan-service-with-jaeger:v1
+        image: codewisdom/ts-travel-plan-service:0.2.0
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -1983,7 +1983,7 @@ spec:
     spec:
       containers:
       - name: ts-travel-service
-        image: codewisdom/ts-travel-service-with-jaeger:v1
+        image: codewisdom/ts-travel-service:0.2.0
         imagePullPolicy: IfNotPresent
         args: ["java", "-Xmx400m",  "-jar", "/app/ts-travel-service-1.0.jar"]
         env:
@@ -2037,7 +2037,7 @@ spec:
     spec:
       containers:
       - name: ts-verification-code-service
-        image: codewisdom/ts-verification-code-service-with-jaeger:v1
+        image: codewisdom/ts-verification-code-service:0.2.0
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -2090,7 +2090,7 @@ spec:
     spec:
       containers:
       - name: ts-voucher-service
-        image: codewisdom/ts-voucher-service-with-jaeger:v1
+        image: codewisdom/ts-voucher-service:0.2.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 16101
@@ -2104,6 +2104,49 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 16101
+          initialDelaySeconds: 160
+          periodSeconds: 10
+          timeoutSeconds: 5
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ts-avatar-service
+  labels:
+    app.kubernetes.io/name: ts-avatar-service
+    app.kubernetes.io/part-of: ts-avatar
+    app.kubernetes.io/component: web
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ts-avatar-service
+      app.kubernetes.io/part-of: ts-avatar
+      app.kubernetes.io/component: web
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ts-avatar-service
+        app.kubernetes.io/part-of: ts-avatar
+        app.kubernetes.io/component: web
+    spec:
+      containers:
+      - name: ts-avatar-service
+        image: codewisdom/ts-avatar-service:0.2.0
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 17001
+        resources:
+          requests:
+            cpu: 50m
+            memory: 200Mi
+          limits:
+            cpu: 200m
+            memory: 500Mi
+        readinessProbe:
+          tcpSocket:
+            port: 17001
           initialDelaySeconds: 160
           periodSeconds: 10
           timeoutSeconds: 5
@@ -2868,4 +2911,22 @@ spec:
   selector:
     app.kubernetes.io/name: ts-voucher-service
     app.kubernetes.io/part-of: ts-voucher
+    app.kubernetes.io/component: web
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ts-avatar-service
+  labels:
+    app.kubernetes.io/name: ts-avatar-service
+    app.kubernetes.io/part-of: ts-avatar
+    app.kubernetes.io/component: web
+spec:
+  ports:
+    - name: http
+      port: 17001
+  selector:
+    app.kubernetes.io/name: ts-avatar-service
+    app.kubernetes.io/part-of: ts-avatar
     app.kubernetes.io/component: web

--- a/manifests/train-ticket-base/app/ts-part2.yaml
+++ b/manifests/train-ticket-base/app/ts-part2.yaml
@@ -1985,7 +1985,7 @@ spec:
       - name: ts-travel-service
         image: codewisdom/ts-travel-service:0.2.0
         imagePullPolicy: IfNotPresent
-        args: ["java", "-Xmx400m",  "-jar", "/app/ts-travel-service-1.0.jar"]
+        args: ["java", "-Xmx500m",  "-jar", "/app/ts-travel-service-1.0.jar"]
         env:
           - name: JAVA_TOOL_OPTIONS
             value: >-
@@ -1997,11 +1997,11 @@ spec:
         - containerPort: 12346
         resources:
           requests:
-            cpu: 300m
-            memory: 800Mi
+            cpu: 200m
+            memory: 600Mi
           limits:
             cpu: 600m
-            memory: 800Mi
+            memory: 1000Mi
         readinessProbe:
           tcpSocket:
             port: 12346

--- a/manifests/train-ticket-base/app/ts-part2.yaml
+++ b/manifests/train-ticket-base/app/ts-part2.yaml
@@ -1096,7 +1096,7 @@ spec:
             cpu: 50m
             memory: 160Mi
           limits:
-            cpu: 200m
+            cpu: 500m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -1468,7 +1468,7 @@ spec:
             cpu: 50m
             memory: 160Mi
           limits:
-            cpu: 200m
+            cpu: 500m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -1521,7 +1521,7 @@ spec:
             cpu: 50m
             memory: 160Mi
           limits:
-            cpu: 200m
+            cpu: 500m
             memory: 700Mi
         readinessProbe:
           tcpSocket:
@@ -1786,7 +1786,7 @@ spec:
             cpu: 50m
             memory: 160Mi
           limits:
-            cpu: 200m
+            cpu: 500m
             memory: 500Mi
         readinessProbe:
           tcpSocket:

--- a/manifests/train-ticket-base/app/ts-part3.yaml
+++ b/manifests/train-ticket-base/app/ts-part3.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: ts-ui-dashboard
-        image: codewisdom/ts-ui-dashboard-with-jaeger:v1
+        image: codewisdom/ts-ui-dashboard:0.2.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080

--- a/manifests/train-ticket-base/loadtest/locustfile.py
+++ b/manifests/train-ticket-base/loadtest/locustfile.py
@@ -65,7 +65,8 @@ def login(client):
     def api_call_admin_login():
         headers = {"Accept": "application/json", "Content-Type": "application/json"}
         body = {"username": "admin", "password": "222222"}
-        response = client.post(url="/api/v1/users/login", headers=headers, json=body, name=get_name_suffix("admin_login"))
+        response = client.post(
+            url="/api/v1/users/login", headers=headers, json=body, name=get_name_suffix("admin_login"))
         response_as_json = get_json_from_response(response)
         return response_as_json, response_as_json["status"]
 
@@ -346,6 +347,7 @@ def get_voucher(client, user_id):
 
 
 class UserNoLogin(HttpUser):
+    weight = 50
 
     def on_start(self):
         self.client.headers.update({"Content-Type": "application/json"})
@@ -362,6 +364,7 @@ class UserNoLogin(HttpUser):
 
 
 class UserBooking(HttpUser):
+    weight = 10
 
     def on_start(self):
         user_id, token = login(self.client)
@@ -384,6 +387,7 @@ class UserBooking(HttpUser):
 
 
 class UserConsignTicket(HttpUser):
+    weight = 5
 
     def on_start(self):
         user_id, token = login(self.client)
@@ -405,6 +409,7 @@ class UserConsignTicket(HttpUser):
 
 
 class UserCancelNoRefund(HttpUser):
+    weight = 1
 
     def on_start(self):
         user_id, token = login(self.client)
@@ -426,6 +431,7 @@ class UserCancelNoRefund(HttpUser):
 
 
 class UserRefundVoucher(HttpUser):
+    weight = 1
 
     def on_start(self):
         user_id, token = login(self.client)


### PR DESCRIPTION
- manifests: replace the container images with those without jaeger
- manifests: adjust resource size
- manifests: increase jmx-exporter resource due to OOMkill
- manifests: enable jmx-exporer cache to avoid the performance degradation of JVM app
- manifests: adjust weights of each user classs of locust
- manifests: adjust ts-travel-service memory size
- manifests: avoid retrying requests in locustfile
- manifests: refactor locustfile in train ticket
