### PR TITLE
Bump version train ticket and Achieve performance stability

### DIFF
--- a/manifests/train-ticket-base/app/kustomization.yaml
+++ b/manifests/train-ticket-base/app/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: train-ticket
 
 resources:
 - ts-ns.yaml
-- jaeger.yaml
+# - jaeger.yaml
 - ts-part1.yaml
 - ts-part2.yaml
 - ts-part3.yaml

--- a/manifests/train-ticket-base/app/kustomization.yaml
+++ b/manifests/train-ticket-base/app/kustomization.yaml
@@ -11,6 +11,10 @@ resources:
 - ts-part3.yaml
 
 configMapGenerator:
+- name: nginx-config
+  files:
+  - ts-ui-dashboard.nginx/nginx.conf
+  - ts-ui-dashboard.nginx/mime.types
 - name: nginxlog-exporter-config
   files:
   - nginxlog-exporter.config.hcl

--- a/manifests/train-ticket-base/app/nginxlog-exporter.config.hcl
+++ b/manifests/train-ticket-base/app/nginxlog-exporter.config.hcl
@@ -5,6 +5,271 @@ listen {
 namespace "nginx" {
   format = "$remote_addr - $remote_user [$time_local] \"$request\" $request_length $status $body_bytes_sent $request_time \"$http_referer\" \"$http_user_agent\" \"$http_x_forwarded_for\" $upstream_response_time"
 
+  relabel "request_uri" {
+    from = "request"
+    split = 2
+    separator = " "
+
+    // if enabled, only include label in response count metric (default is false)
+    only_counter = false
+
+    match "^/api/v1/travelservice" {
+      replacement = "/api/v1/travelservice"
+    }
+    match "^/api/v1/travel2service" {
+      replacement = "/api/v1/travel2service"
+    }
+    match "^/api/v1/userservice/users" {
+      replacement = "/api/v1/userservice/users"
+    }
+    match "^/api/v1/users/auth" {
+      replacement = "/api/v1/users/auth"
+    }
+    match "^/api/v1/users/login" {
+      replacement = "/api/v1/users/login"
+    }
+    match "^/api/v1/verifycode/generate" {
+      replacement = "/api/v1/verifycode/generate"
+    }
+    match "^/api/v1/stationservice" {
+      replacement = "/api/v1/stationservice"
+    }
+    match "^/api/v1/trainservice" {
+      replacement = "/api/v1/trainservice"
+    }
+    match "^/api/v1/configservice" {
+      replacement = "/api/v1/configservice"
+    }
+    match "^/api/v1/securityservice" {
+      replacement = "/api/v1/securityservice"
+    }
+    match "^/api/v1/executeservice/execute/execute" {
+      replacement = "/api/v1/executeservice/execute/execute"
+    }
+    match "^/api/v1/executeservice/execute/collected" {
+      replacement = "/api/v1/executeservice/execute/collected"
+    }
+    match "^/api/v1/contactservice/contacts" {
+      replacement = "/api/v1/contactservice/contacts"
+    }
+    match "^/api/v1/contactservice/contacts/account" {
+      replacement = "/api/v1/contactservice/contacts/account"
+    }
+    match "^/api/v1/orderservice/order/refresh" {
+      replacement = "/api/v1/orderservice/order/refresh"
+    }
+    match "^/api/v1/orderOtherService/orderOther/refresh" {
+      replacement = "/api/v1/orderOtherService/orderOther/refresh"
+    }
+    match "^/api/v1/preserveservice/preserve" {
+      replacement = "/api/v1/preserveservice/preserve"
+    }
+    match "^/api/v1/preserveotherservice/preserveOther" {
+      replacement = "/api/v1/preserveotherservice/preserveOther"
+    }
+    match "^/price/query" {
+      replacement = "/price/query"
+    }
+    match "^/price/queryAll" {
+      replacement = "/price/queryAll"
+    }
+    match "^/price/create" {
+      replacement = "/price/create"
+    }
+    match "^/price/delete" {
+      replacement = "/price/delete"
+    }
+    match "^/price/update" {
+      replacement = "/price/update"
+    }
+    match "^/basic/queryForTravel" {
+      replacement = "/basic/queryForTravel"
+    }
+    match "^/ticketinfo/queryForTravel" {
+      replacement = "/ticketinfo/queryForTravel"
+    }
+    match "^/notification/preserve_success" {
+      replacement = "/notification/preserve_success"
+    }
+    match "^/notification/order_create_success" {
+      replacement = "/notification/order_create_success"
+    }
+    match "^/notification/order_changed_success" {
+      replacement = "/notification/order_changed_success"
+    }
+    match "^/api/v1/inside_pay_service/inside_payment" {
+      replacement = "/api/v1/inside_pay_service/inside_payment"
+    }
+    match "^/payment/pay" {
+      replacement = "/payment/pay"
+    }
+    match "^/payment/addMoney" {
+      replacement = "/payment/addMoney"
+    }
+    match "^/payment/query" {
+      replacement = "/payment/query"
+    }
+    match "^/rebook" {
+      replacement = "/rebook"
+    }
+    match "^/api/v1/cancelservice/cancel" {
+      replacement = "/api/v1/cancelservice/cancel"
+    }
+    match "^/api/v1/cancelservice/cancel/refound" {
+      replacement = "/api/v1/cancelservice/cancel/refound"
+    }
+    match "^/api/v1/stationservice/stations/name" {
+      replacement = "/api/v1/stationservice/stations/name"
+    }
+    match "^/api/v1/rebookservice/rebook" {
+      replacement = "/api/v1/rebookservice/rebook"
+    }
+    match "^/api/v1/rebookservice/rebook/difference" {
+      replacement = "/api/v1/rebookservice/rebook/difference"
+    }
+    match "^/route/createAndModify" {
+      replacement = "/route/createAndModify"
+    }
+    match "^/route/delete" {
+      replacement = "/route/delete"
+    }
+    match "^/route/queryAll" {
+      replacement = "/route/queryAll"
+    }
+    match "^/route/queryById/" {
+      replacement = "/route/queryById/:id"
+    }
+    match "^/route/queryByStartAndTerminal" {
+      replacement = "/route/queryByStartAndTerminal"
+    }
+    match "^/api/v1/assuranceservice/assurances/types" {
+      replacement = "/api/v1/assuranceservice/assurances/types"
+    }
+    match "^/assurance/getAssuranceById" {
+      replacement = "/assurance/getAssuranceById/:id"
+    }
+    match "^/assurance/findAssuranceByOrderId" {
+      replacement = "/assurance/findAssuranceByOrderId/:id"
+    }
+    match "^/assurance/findAll" {
+      replacement = "/assurance/findAll"
+    }
+    match "^/assurance/create" {
+      replacement = "/assurance/create"
+    }
+    match "^/assurance/deleteAssurance" {
+      replacement = "/assurance/deleteAssurance"
+    }
+    match "^/assurance/deleteAssuranceByOrderId" {
+      replacement = "/assurance/deleteAssuranceByOrderId/:id"
+    }
+    match "^/assurance/modifyAssurance" {
+      replacement = "/assurance/modifyAssurance"
+    }
+    match "^/office/getRegionList" {
+      replacement = "/office/getRegionList"
+    }
+    match "^/office/getAll" {
+      replacement = "/office/getAll"
+    }
+    match "^/office/getSpecificOffices" {
+      replacement = "/office/getSpecificOffices"
+    }
+    match "^/office/addOffice" {
+      replacement = "/office/addOffice"
+    }
+    match "^/office/deleteOffice" {
+      replacement = "/office/deleteOffice"
+    }
+    match "^/office/updateOffice" {
+      replacement = "/office/updateOffice"
+    }
+    match "^/travelPlan/getTransferResult" {
+      replacement = "/travelPlan/getTransferResult"
+    }
+    match "^/api/v1/travelplanservice/travelPlan/cheapest" {
+      replacement = "/api/v1/travelplanservice/travelPlan/cheapest"
+    }
+    match "^/api/v1/travelplanservice/travelPlan/quickest" {
+      replacement = "/api/v1/travelplanservice/travelPlan/quickest"
+    }
+    match "^/api/v1/travelplanservice/travelPlan/minStation" {
+      replacement = "/api/v1/travelplanservice/travelPlan/minStation"
+    }
+    match "^/api/v1/consignservice/consigns" {
+      replacement = "/api/v1/consignservice/consigns"
+    }
+    match "^/api/v1/consignservice/consigns/account" {
+      replacement = "/api/v1/consignservice/consigns/account"
+    }
+    match "^/getVoucher" {
+      replacement = "/getVoucher"
+    }
+    match "^/routePlan/minStopStations" {
+      replacement = "/routePlan/minStopStations"
+    }
+    match "^/routePlan/cheapestRoute" {
+      replacement = "/routePlan/cheapestRoute"
+    }
+    match "^/routePlan/quickestRoute" {
+      replacement = "/routePlan/quickestRoute"
+    }
+    match "^/api/v1/foodservice" {
+      replacement = "/api/v1/foodservice"
+    }
+    match "^/api/v1/foodservice/foods" {
+      replacement = "/api/v1/foodservice/foods"
+    }
+    match "^/food/createFoodOrder" {
+      replacement = "/food/createFoodOrder"
+    }
+    match "^/food/cancelFoodOrder" {
+      replacement = "/food/cancelFoodOrder"
+    }
+    match "^/food/updateFoodOrder" {
+      replacement = "/food/updateFoodOrder"
+    }
+    match "^/food/findAllFoodOrder" {
+      replacement = "/food/findAllFoodOrder"
+    }
+    match "^/food/findFoodOrderByOrderId" {
+      replacement = "/food/findFoodOrderByOrderId/:id"
+    }
+    match "^/news-service/news" {
+      replacement = "/news-service/news"
+    }
+    match "^/api/v1/adminbasicservice/adminbasic/contacts" {
+      replacement = "/api/v1/adminbasicservice/adminbasic/contacts"
+    }
+    match "^/api/v1/adminbasicservice/adminbasic/stations" {
+      replacement = "/api/v1/adminbasicservice/adminbasic/stations"
+    }
+    match "^/api/v1/adminbasicservice/adminbasic/trains" {
+      replacement = "/api/v1/adminbasicservice/adminbasic/trains"
+    }
+    match "^/api/v1/adminbasicservice/adminbasic/prices" {
+      replacement = "/api/v1/adminbasicservice/adminbasic/prices"
+    }
+    match "^/api/v1/adminbasicservice/adminbasic/configs" {
+      replacement = "/api/v1/adminbasicservice/adminbasic/configs"
+    }
+    match "^/api/v1/adminorderservice/adminorder" {
+      replacement = "/api/v1/adminorderservice/adminorder"
+    }
+    match "^/api/v1/adminrouteservice/adminroute" {
+      replacement = "/api/v1/adminrouteservice/adminroute"
+    }
+    match "^/api/v1/admintravelservice/admintravel" {
+      replacement = "/api/v1/admintravelservice/admintravel"
+    }
+    match "^/api/v1/adminuserservice/users" {
+      replacement = "/api/v1/adminuserservice/users"
+    }
+    match "^/api/v1/avatar" {
+      replacement = "/api/v1/avatar"
+    }
+  }
+
   source = {
     files = [
       "/etc/nginxlog/access.log"

--- a/manifests/train-ticket-base/app/nginxlog-exporter.config.hcl
+++ b/manifests/train-ticket-base/app/nginxlog-exporter.config.hcl
@@ -3,6 +3,8 @@ listen {
 }
 
 namespace "nginx" {
+  format = "$remote_addr - $remote_user [$time_local] \"$request\" $request_length $status $body_bytes_sent $request_time \"$http_referer\" \"$http_user_agent\" \"$http_x_forwarded_for\" $upstream_response_time"
+
   source = {
     files = [
       "/etc/nginxlog/access.log"
@@ -10,10 +12,6 @@ namespace "nginx" {
   }
 
   print_log = true
-
-  labels {
-    app = "default"
-  }
 
   histogram_buckets = [.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10]
 }

--- a/manifests/train-ticket-base/app/nginxlog-exporter.config.hcl
+++ b/manifests/train-ticket-base/app/nginxlog-exporter.config.hcl
@@ -9,9 +9,11 @@ namespace "nginx" {
     ]
   }
 
-  format = "$remote_addr - $remote_user [$time_local] \"$request\" $status $body_bytes_sent \"$http_referer\" \"$http_user_agent\""
+  print_log = true
 
   labels {
     app = "default"
   }
+
+  histogram_buckets = [.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10]
 }

--- a/manifests/train-ticket-base/app/patch-jmx-exporter.yaml
+++ b/manifests/train-ticket-base/app/patch-jmx-exporter.yaml
@@ -21,12 +21,9 @@ spec:
             - name: configmap-jmx
               mountPath: /tmp
           resources:
-            requests:
-              cpu: 50m
-              memory: 100Mi
             limits:
               cpu: 100m
-              memory: 200Mi
+              memory: 100Mi
       volumes:
         - name: configmap-jmx
           configMap:

--- a/manifests/train-ticket-base/app/patch-jmx-exporter.yaml
+++ b/manifests/train-ticket-base/app/patch-jmx-exporter.yaml
@@ -23,7 +23,7 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 100Mi
+              memory: 200Mi
       volumes:
         - name: configmap-jmx
           configMap:

--- a/manifests/train-ticket-base/app/ts-part1.yaml
+++ b/manifests/train-ticket-base/app/ts-part1.yaml
@@ -802,6 +802,74 @@ spec:
             requests:
               cpu: 50m
               memory: 100Mi
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ts-delivery-mongo
+  labels:
+    app.kubernetes.io/name: ts-delivery-mongo
+    app.kubernetes.io/part-of: ts-deliver
+    app.kubernetes.io/component: db
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ts-delivery-mongo
+      app.kubernetes.io/part-of: ts-deliver
+      app.kubernetes.io/component: db
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ts-delivery-mongo
+        app.kubernetes.io/part-of: ts-deliver
+        app.kubernetes.io/component: db
+    spec:
+      containers:
+        - name: ts-delivery-mongo
+          image: mongo
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 27017
+          resources:
+            requests:
+              cpu: 50m
+              memory: 100Mi
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rabbitmq
+  labels:
+    app.kubernetes.io/name: rabbitmq
+    app.kubernetes.io/component: mq
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: rabbitmq
+      app.kubernetes.io/component: mq
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: rabbitmq
+        app.kubernetes.io/component: mq
+    spec:
+      containers:
+        - name: rabbitmq
+          image: rabbitmq:3.10.5
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 5672
+          resources:
+            requests:
+              cpu: 100m
+              memory: 200Mi
+            limits:
+              cpu: 500m
+              memory: 500Mi
 
 ---
 apiVersion: v1
@@ -1214,3 +1282,35 @@ spec:
     app.kubernetes.io/component: db
 
 ---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ts-delivery-mongo
+  labels:
+    app.kubernetes.io/name: ts-delivery-mongo
+    app.kubernetes.io/part-of: ts-delivery
+    app.kubernetes.io/component: db
+spec:
+  ports:
+    - port: 27017
+  selector:
+    app.kubernetes.io/name: ts-delivery-mongo
+    app.kubernetes.io/part-of: ts-delivery
+    app.kubernetes.io/component: db
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: rabbitmq
+  labels:
+    app.kubernetes.io/name: rabbitmq
+    app.kubernetes.io/component: mq
+spec:
+  ports:
+    - port: 5672
+  selector:
+    app.kubernetes.io/name: rabbitmq
+    app.kubernetes.io/component: mq

--- a/manifests/train-ticket-base/app/ts-part1.yaml
+++ b/manifests/train-ticket-base/app/ts-part1.yaml
@@ -28,7 +28,7 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 100Mi
 ---
 
@@ -62,7 +62,7 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 100Mi
 ---
 
@@ -96,7 +96,7 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 100Mi
 
 ---
@@ -131,7 +131,7 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 100Mi
 
 ---
@@ -166,7 +166,7 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 100Mi
 
 ---
@@ -201,7 +201,7 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 100Mi
 
 ---
@@ -236,7 +236,7 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 100Mi
 
 ---
@@ -271,7 +271,7 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 100Mi
 
 ---
@@ -306,7 +306,7 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 100Mi
 
 ---
@@ -341,7 +341,7 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 100Mi
 
 ---
@@ -376,7 +376,7 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 100Mi
 
 ---
@@ -411,7 +411,7 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 100Mi
 
 ---
@@ -446,7 +446,7 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 100Mi
 
 ---
@@ -481,7 +481,7 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 100Mi
 
 ---
@@ -516,7 +516,7 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 100Mi
 
 ---
@@ -551,7 +551,7 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 100Mi
 
 ---
@@ -586,7 +586,7 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 100Mi
 
 
@@ -626,7 +626,7 @@ spec:
         - containerPort: 3306
         resources:
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 100Mi
 
 ---
@@ -661,7 +661,7 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 100Mi
 
 ---
@@ -696,7 +696,7 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 100Mi
 
 ---
@@ -731,7 +731,7 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 100Mi
 
 ---
@@ -766,7 +766,7 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 100Mi
 ---
 
@@ -800,7 +800,7 @@ spec:
             - containerPort: 27017
           resources:
             requests:
-              cpu: 100m
+              cpu: 50m
               memory: 100Mi
 ---
 
@@ -834,7 +834,7 @@ spec:
             - containerPort: 27017
           resources:
             requests:
-              cpu: 100m
+              cpu: 50m
               memory: 100Mi
 ---
 
@@ -865,7 +865,7 @@ spec:
             - containerPort: 5672
           resources:
             requests:
-              cpu: 100m
+              cpu: 50m
               memory: 200Mi
             limits:
               cpu: 500m

--- a/manifests/train-ticket-base/app/ts-part1.yaml
+++ b/manifests/train-ticket-base/app/ts-part1.yaml
@@ -28,7 +28,7 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 100Mi
 ---
 
@@ -62,7 +62,7 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 100Mi
 ---
 
@@ -96,7 +96,7 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 100Mi
 
 ---
@@ -131,7 +131,7 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 100Mi
 
 ---
@@ -166,7 +166,7 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 100Mi
 
 ---
@@ -201,7 +201,7 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 100Mi
 
 ---
@@ -236,7 +236,7 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 100Mi
 
 ---
@@ -271,7 +271,7 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 100Mi
 
 ---
@@ -306,7 +306,7 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 100Mi
 
 ---
@@ -341,7 +341,7 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 100Mi
 
 ---
@@ -376,7 +376,7 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 100Mi
 
 ---
@@ -411,7 +411,7 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 100Mi
 
 ---
@@ -446,7 +446,7 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 100Mi
 
 ---
@@ -481,7 +481,7 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 100Mi
 
 ---
@@ -516,7 +516,7 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 100Mi
 
 ---
@@ -551,7 +551,7 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 100Mi
 
 ---
@@ -586,7 +586,7 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 100Mi
 
 
@@ -626,7 +626,7 @@ spec:
         - containerPort: 3306
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 100Mi
 
 ---
@@ -661,7 +661,7 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 100Mi
 
 ---
@@ -696,7 +696,7 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 100Mi
 
 ---
@@ -731,7 +731,7 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 100Mi
 
 ---
@@ -766,7 +766,7 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 100Mi
 ---
 
@@ -800,7 +800,7 @@ spec:
             - containerPort: 27017
           resources:
             requests:
-              cpu: 50m
+              cpu: 100m
               memory: 100Mi
 ---
 
@@ -834,7 +834,7 @@ spec:
             - containerPort: 27017
           resources:
             requests:
-              cpu: 50m
+              cpu: 100m
               memory: 100Mi
 ---
 

--- a/manifests/train-ticket-base/app/ts-part2.yaml
+++ b/manifests/train-ticket-base/app/ts-part2.yaml
@@ -481,23 +481,23 @@ kind: Deployment
 metadata:
   name: ts-consign-price-service
   labels:
-    app.kubernetes.io/name: ts-config-price-service
-    app.kubernetes.io/part-of: ts-config-price
+    app.kubernetes.io/name: ts-consign-price-service
+    app.kubernetes.io/part-of: ts-consign-price
     app.kubernetes.io/component: web
     runtime: jvm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: ts-config-price-service
-      app.kubernetes.io/part-of: ts-config-price
+      app.kubernetes.io/name: ts-consign-price-service
+      app.kubernetes.io/part-of: ts-consign-price
       app.kubernetes.io/component: web
       runtime: jvm
   replicas: 1
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: ts-config-price-service
-        app.kubernetes.io/part-of: ts-config-price
+        app.kubernetes.io/name: ts-consign-price-service
+        app.kubernetes.io/part-of: ts-consign-price
         app.kubernetes.io/component: web
         runtime: jvm
     spec:
@@ -892,7 +892,7 @@ spec:
         - containerPort: 12340
         resources:
           requests:
-            cpu: 500m
+            cpu: 200m
             memory: 500Mi
           limits:
             cpu: 700m
@@ -2016,7 +2016,7 @@ spec:
             cpu: 200m
             memory: 600Mi
           limits:
-            cpu: 600m
+            cpu: 1000m
             memory: 1000Mi
         readinessProbe:
           tcpSocket:
@@ -2801,7 +2801,6 @@ metadata:
     app.kubernetes.io/part-of: ts-auth
     app.kubernetes.io/component: web
 spec:
-  type: LoadBalancer
   ports:
     - name: http
       port: 12340

--- a/manifests/train-ticket-base/app/ts-part2.yaml
+++ b/manifests/train-ticket-base/app/ts-part2.yaml
@@ -622,8 +622,8 @@ spec:
         - containerPort: 12347
         resources:
           requests:
-            cpu: 100m
-            memory: 160Mi
+            cpu: 50m
+            memory: 100Mi
           limits:
             cpu: 500m
             memory: 500Mi
@@ -839,7 +839,7 @@ spec:
         resources:
           requests:
             cpu: 50m
-            memory: 160Mi
+            memory: 300Mi
           limits:
             cpu: 200m
             memory: 500Mi
@@ -938,7 +938,7 @@ spec:
         - containerPort: 12862
         resources:
           requests:
-            cpu: 50m
+            cpu: 10m
             memory: 50Mi
           limits:
             cpu: 200m
@@ -1048,8 +1048,8 @@ spec:
         - containerPort: 12032
         resources:
           requests:
-            cpu: 100m
-            memory: 160Mi
+            cpu: 50m
+            memory: 100Mi
           limits:
             cpu: 200m
             memory: 500Mi
@@ -1090,6 +1090,7 @@ spec:
       - name: ts-order-service
         image: codewisdom/ts-order-service:0.2.1
         imagePullPolicy: IfNotPresent
+        args: ["java", "-Xmx400m",  "-jar", "/app/ts-order-service-1.0.jar"]
         env:
           - name: JAVA_TOOL_OPTIONS
             value: >-
@@ -1154,7 +1155,7 @@ spec:
         - containerPort: 19001
         resources:
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 160Mi
           limits:
             cpu: 500m
@@ -1211,7 +1212,7 @@ spec:
         - containerPort: 14569
         resources:
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 160Mi
           limits:
             cpu: 500m
@@ -1269,8 +1270,8 @@ spec:
         - containerPort: 14568
         resources:
           requests:
-            cpu: 100m
-            memory: 160Mi
+            cpu: 50m
+            memory: 400Mi
           limits:
             cpu: 500m
             memory: 800Mi
@@ -1375,7 +1376,7 @@ spec:
         - containerPort: 18886
         resources:
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 160Mi
           limits:
             cpu: 500m
@@ -1428,7 +1429,7 @@ spec:
         - containerPort: 14578
         resources:
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 160Mi
           limits:
             cpu: 500m
@@ -1746,7 +1747,7 @@ spec:
         - containerPort: 16108
         resources:
           requests:
-            cpu: 50m
+            cpu: 10m
             memory: 100Mi
           limits:
             cpu: 500m
@@ -1894,7 +1895,6 @@ spec:
       - name: ts-travel2-service
         image: codewisdom/ts-travel2-service:0.2.1
         imagePullPolicy: IfNotPresent
-        args: ["java", "-Xmx200m",  "-jar", "/app/ts-travel2-service-1.0.jar"]
         env:
           - name: JAVA_TOOL_OPTIONS
             value: >-
@@ -1906,8 +1906,8 @@ spec:
         - containerPort: 16346
         resources:
           requests:
-            cpu: 100m
-            memory: 200Mi
+            cpu: 50m
+            memory: 300Mi
           limits:
             cpu: 500m
             memory: 400Mi
@@ -1959,8 +1959,8 @@ spec:
         - containerPort: 14322
         resources:
           requests:
-            cpu: 100m
-            memory: 160Mi
+            cpu: 50m
+            memory: 300Mi
           limits:
             cpu: 500m
             memory: 500Mi
@@ -2067,10 +2067,10 @@ spec:
           - containerPort: 18808
         resources:
           requests:
-            cpu: 50m
+            cpu: 10m
             memory: 100Mi
           limits:
-            cpu: 500m
+            cpu: 200m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -2166,7 +2166,7 @@ spec:
         - containerPort: 16101
         resources:
           requests:
-            cpu: 50m
+            cpu: 10m
             memory: 50Mi
           limits:
             cpu: 100m
@@ -2209,7 +2209,7 @@ spec:
         - containerPort: 17001
         resources:
           requests:
-            cpu: 50m
+            cpu: 10m
             memory: 160Mi
           limits:
             cpu: 200m

--- a/manifests/train-ticket-base/app/ts-part2.yaml
+++ b/manifests/train-ticket-base/app/ts-part2.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: ts-admin-basic-info-service
-        image: codewisdom/ts-admin-basic-info-service:0.2.0
+        image: codewisdom/ts-admin-basic-info-service:0.2.1
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -79,7 +79,7 @@ spec:
     spec:
       containers:
       - name: ts-admin-order-service
-        image: codewisdom/ts-admin-order-service:0.2.0
+        image: codewisdom/ts-admin-order-service:0.2.1
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -132,7 +132,7 @@ spec:
     spec:
       containers:
       - name: ts-admin-route-service
-        image: codewisdom/ts-admin-route-service:0.2.0
+        image: codewisdom/ts-admin-route-service:0.2.1
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -185,7 +185,7 @@ spec:
     spec:
       containers:
       - name: ts-admin-travel-service
-        image: codewisdom/ts-admin-travel-service:0.2.0
+        image: codewisdom/ts-admin-travel-service:0.2.1
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -238,7 +238,7 @@ spec:
     spec:
       containers:
       - name: ts-admin-user-service
-        image: codewisdom/ts-admin-user-service:0.2.0
+        image: codewisdom/ts-admin-user-service:0.2.1
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -291,7 +291,7 @@ spec:
     spec:
       containers:
       - name: ts-assurance-service
-        image: codewisdom/ts-assurance-service:0.2.0
+        image: codewisdom/ts-assurance-service:0.2.1
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -344,7 +344,7 @@ spec:
     spec:
       containers:
       - name: ts-basic-service
-        image: codewisdom/ts-basic-service:0.2.0
+        image: codewisdom/ts-basic-service:0.2.1
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -397,7 +397,7 @@ spec:
     spec:
       containers:
       - name: ts-cancel-service
-        image: codewisdom/ts-cancel-service:0.2.0
+        image: codewisdom/ts-cancel-service:0.2.1
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -450,7 +450,7 @@ spec:
     spec:
       containers:
       - name: ts-config-service
-        image: codewisdom/ts-config-service:0.2.0
+        image: codewisdom/ts-config-service:0.2.1
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -503,7 +503,7 @@ spec:
     spec:
       containers:
       - name: ts-consign-price-service
-        image: codewisdom/ts-consign-price-service:0.2.0
+        image: codewisdom/ts-consign-price-service:0.2.1
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -556,7 +556,7 @@ spec:
     spec:
       containers:
       - name: ts-consign-service
-        image: codewisdom/ts-consign-service:0.2.0
+        image: codewisdom/ts-consign-service:0.2.1
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -609,7 +609,7 @@ spec:
     spec:
       containers:
       - name: ts-contacts-service
-        image: codewisdom/ts-contacts-service:0.2.0
+        image: codewisdom/ts-contacts-service:0.2.1
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -662,7 +662,7 @@ spec:
     spec:
       containers:
       - name: ts-execute-service
-        image: codewisdom/ts-execute-service:0.2.0
+        image: codewisdom/ts-execute-service:0.2.1
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -715,7 +715,7 @@ spec:
     spec:
       containers:
       - name: ts-food-map-service
-        image: codewisdom/ts-food-map-service:0.2.0
+        image: codewisdom/ts-food-map-service:0.2.1
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -768,7 +768,7 @@ spec:
     spec:
       containers:
       - name: ts-food-service
-        image: codewisdom/ts-food-service:0.2.0
+        image: codewisdom/ts-food-service:0.2.1
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -777,6 +777,10 @@ spec:
                   -Dcom.sun.management.jmxremote.port=5555
                   -Dcom.sun.management.jmxremote.authenticate=false
                   -Dcom.sun.management.jmxremote.ssl=false
+          - name: rabbitmq_host
+            value: "rabbitmq"
+          - name: rabbitmq_port
+            value: "5672"
         ports:
         - containerPort: 18856
         resources:
@@ -821,7 +825,7 @@ spec:
     spec:
       containers:
       - name: ts-inside-payment-service
-        image: codewisdom/ts-inside-payment-service:0.2.0
+        image: codewisdom/ts-inside-payment-service:0.2.1
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -874,7 +878,7 @@ spec:
     spec:
       containers:
       - name: ts-auth-service
-        image: codewisdom/ts-auth-service:0.2.0
+        image: codewisdom/ts-auth-service:0.2.1
         imagePullPolicy: IfNotPresent
         args: ["java", "-Xmx400m",  "-jar", "/app/ts-auth-service-1.0.jar"]
         env:
@@ -928,7 +932,7 @@ spec:
     spec:
       containers:
       - name: ts-news-service
-        image: codewisdom/ts-news-service:0.2.0
+        image: codewisdom/ts-news-service:0.2.1
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 12862
@@ -974,7 +978,7 @@ spec:
     spec:
       containers:
       - name: ts-notification-service
-        image: codewisdom/ts-notification-service:0.2.0
+        image: codewisdom/ts-notification-service:0.2.1
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -983,6 +987,10 @@ spec:
                   -Dcom.sun.management.jmxremote.port=5555
                   -Dcom.sun.management.jmxremote.authenticate=false
                   -Dcom.sun.management.jmxremote.ssl=false
+          - name: rabbitmq_host
+            value: "rabbitmq"
+          - name: rabbitmq_port
+            value: "5672"
         ports:
         - containerPort: 17853
         resources:
@@ -1027,7 +1035,7 @@ spec:
     spec:
       containers:
       - name: ts-order-other-service
-        image: codewisdom/ts-order-other-service:0.2.0
+        image: codewisdom/ts-order-other-service:0.2.1
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -1080,7 +1088,7 @@ spec:
     spec:
       containers:
       - name: ts-order-service
-        image: codewisdom/ts-order-service:0.2.0
+        image: codewisdom/ts-order-service:0.2.1
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -1133,7 +1141,7 @@ spec:
     spec:
       containers:
       - name: ts-payment-service
-        image: codewisdom/ts-payment-service:0.2.0
+        image: codewisdom/ts-payment-service:0.2.1
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -1186,7 +1194,7 @@ spec:
     spec:
       containers:
       - name: ts-preserve-other-service
-        image: codewisdom/ts-preserve-other-service:0.2.0
+        image: codewisdom/ts-preserve-other-service:0.2.1
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -1195,6 +1203,10 @@ spec:
                   -Dcom.sun.management.jmxremote.port=5555
                   -Dcom.sun.management.jmxremote.authenticate=false
                   -Dcom.sun.management.jmxremote.ssl=false
+          - name: rabbitmq_host
+            value: "rabbitmq"
+          - name: rabbitmq_port
+            value: "5672"
         ports:
         - containerPort: 14569
         resources:
@@ -1239,7 +1251,7 @@ spec:
     spec:
       containers:
       - name: ts-preserve-service
-        image: codewisdom/ts-preserve-service:0.2.0
+        image: codewisdom/ts-preserve-service:0.2.1
         imagePullPolicy: IfNotPresent
         args: ["java", "-Xmx400m",  "-jar", "/app/ts-preserve-service-1.0.jar"]
         env:
@@ -1249,6 +1261,10 @@ spec:
                   -Dcom.sun.management.jmxremote.port=5555
                   -Dcom.sun.management.jmxremote.authenticate=false
                   -Dcom.sun.management.jmxremote.ssl=false
+          - name: rabbitmq_host
+            value: "rabbitmq"
+          - name: rabbitmq_port
+            value: "5672"
         ports:
         - containerPort: 14568
         resources:
@@ -1293,7 +1309,7 @@ spec:
     spec:
       containers:
       - name: ts-price-service
-        image: codewisdom/ts-price-service:0.2.0
+        image: codewisdom/ts-price-service:0.2.1
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -1346,7 +1362,7 @@ spec:
     spec:
       containers:
       - name: ts-rebook-service
-        image: codewisdom/ts-rebook-service:0.2.0
+        image: codewisdom/ts-rebook-service:0.2.1
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -1399,7 +1415,7 @@ spec:
     spec:
       containers:
       - name: ts-route-plan-service
-        image: codewisdom/ts-route-plan-service:0.2.0
+        image: codewisdom/ts-route-plan-service:0.2.1
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -1452,7 +1468,7 @@ spec:
     spec:
       containers:
       - name: ts-route-service
-        image: codewisdom/ts-route-service:0.2.0
+        image: codewisdom/ts-route-service:0.2.1
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -1505,7 +1521,7 @@ spec:
     spec:
       containers:
       - name: ts-seat-service
-        image: codewisdom/ts-seat-service:0.2.0
+        image: codewisdom/ts-seat-service:0.2.1
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -1558,7 +1574,7 @@ spec:
     spec:
       containers:
       - name: ts-security-service
-        image: codewisdom/ts-security-service:0.2.0
+        image: codewisdom/ts-security-service:0.2.1
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -1611,7 +1627,7 @@ spec:
     spec:
       containers:
       - name: ts-user-service
-        image: codewisdom/ts-user-service:0.2.0
+        image: codewisdom/ts-user-service:0.2.1
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -1664,7 +1680,7 @@ spec:
     spec:
       containers:
       - name: ts-station-service
-        image: codewisdom/ts-station-service:0.2.0
+        image: codewisdom/ts-station-service:0.2.1
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -1717,7 +1733,7 @@ spec:
     spec:
       containers:
       - name: ts-ticket-office-service
-        image: codewisdom/ts-ticket-office-service:0.2.0
+        image: codewisdom/ts-ticket-office-service:0.2.1
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -1770,7 +1786,7 @@ spec:
     spec:
       containers:
       - name: ts-ticketinfo-service
-        image: codewisdom/ts-ticketinfo-service:0.2.0
+        image: codewisdom/ts-ticketinfo-service:0.2.1
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -1823,7 +1839,7 @@ spec:
     spec:
       containers:
       - name: ts-train-service
-        image: codewisdom/ts-train-service:0.2.0
+        image: codewisdom/ts-train-service:0.2.1
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -1876,7 +1892,7 @@ spec:
     spec:
       containers:
       - name: ts-travel2-service
-        image: codewisdom/ts-travel2-service:0.2.0
+        image: codewisdom/ts-travel2-service:0.2.1
         imagePullPolicy: IfNotPresent
         args: ["java", "-Xmx200m",  "-jar", "/app/ts-travel2-service-1.0.jar"]
         env:
@@ -1930,7 +1946,7 @@ spec:
     spec:
       containers:
       - name: ts-travel-plan-service
-        image: codewisdom/ts-travel-plan-service:0.2.0
+        image: codewisdom/ts-travel-plan-service:0.2.1
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -1983,7 +1999,7 @@ spec:
     spec:
       containers:
       - name: ts-travel-service
-        image: codewisdom/ts-travel-service:0.2.0
+        image: codewisdom/ts-travel-service:0.2.1
         imagePullPolicy: IfNotPresent
         args: ["java", "-Xmx500m",  "-jar", "/app/ts-travel-service-1.0.jar"]
         env:
@@ -2006,6 +2022,60 @@ spec:
           tcpSocket:
             port: 12346
           initialDelaySeconds: 160
+          periodSeconds: 10
+          timeoutSeconds: 5
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ts-delivery-service
+  labels:
+    app.kubernetes.io/name: ts-delivery-service
+    app.kubernetes.io/part-of: ts-delivery
+    app.kubernetes.io/component: web
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ts-delivery-service
+      app.kubernetes.io/part-of: ts-delivery
+      app.kubernetes.io/component: web
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ts-delivery-service
+        app.kubernetes.io/part-of: ts-delivery
+        app.kubernetes.io/component: web
+    spec:
+      containers:
+      - name: ts-delivery-service
+        image: codewisdom/ts-delivery-service:0.2.1
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: rabbitmq_host
+            value: "rabbitmq"
+          - name: rabbitmq_port
+            value: "5672"
+          - name: JAVA_TOOL_OPTIONS
+            value: >-
+                  -Dcom.sun.management.jmxremote
+                  -Dcom.sun.management.jmxremote.port=5555
+                  -Dcom.sun.management.jmxremote.authenticate=false
+                  -Dcom.sun.management.jmxremote.ssl=false
+        ports:
+          - containerPort: 18808
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+          limits:
+            cpu: 500m
+            memory: 500Mi
+        readinessProbe:
+          tcpSocket:
+            port: 18808
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
 ---
@@ -2037,7 +2107,7 @@ spec:
     spec:
       containers:
       - name: ts-verification-code-service
-        image: codewisdom/ts-verification-code-service:0.2.0
+        image: codewisdom/ts-verification-code-service:0.2.1
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_TOOL_OPTIONS
@@ -2090,7 +2160,7 @@ spec:
     spec:
       containers:
       - name: ts-voucher-service
-        image: codewisdom/ts-voucher-service:0.2.0
+        image: codewisdom/ts-voucher-service:0.2.1
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 16101
@@ -2133,7 +2203,7 @@ spec:
     spec:
       containers:
       - name: ts-avatar-service
-        image: codewisdom/ts-avatar-service:0.2.0
+        image: codewisdom/ts-avatar-service:0.2.1
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 17001
@@ -2893,6 +2963,23 @@ spec:
     app.kubernetes.io/part-of: ts-verification-code
     app.kubernetes.io/component: web
 
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ts-delivery-service
+  labels:
+    app.kubernetes.io/name: ts-delivery-service
+    app.kubernetes.io/part-of: ts-delivery
+    app.kubernetes.io/component: web
+spec:
+  ports:
+    - name: http
+      port: 18808
+  selector:
+    app.kubernetes.io/name: ts-delivery-service
+    app.kubernetes.io/part-of: ts-delivery
+    app.kubernetes.io/component: web
 
 ---
 

--- a/manifests/train-ticket-base/app/ts-part2.yaml
+++ b/manifests/train-ticket-base/app/ts-part2.yaml
@@ -38,7 +38,7 @@ spec:
         - containerPort: 18767
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 100Mi
           limits:
             cpu: 200m
@@ -92,7 +92,7 @@ spec:
         - containerPort: 16112
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 160Mi
           limits:
             cpu: 200m
@@ -145,7 +145,7 @@ spec:
         - containerPort: 16113
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 160Mi
           limits:
             cpu: 200m
@@ -198,7 +198,7 @@ spec:
         - containerPort: 16114
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 160Mi
           limits:
             cpu: 200m
@@ -251,7 +251,7 @@ spec:
         - containerPort: 16115
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 160Mi
           limits:
             cpu: 200m
@@ -304,7 +304,7 @@ spec:
         - containerPort: 18888
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 160Mi
           limits:
             cpu: 200m
@@ -357,7 +357,7 @@ spec:
         - containerPort: 15680
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 160Mi
           limits:
             cpu: 500m
@@ -410,7 +410,7 @@ spec:
         - containerPort: 18885
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 160Mi
           limits:
             cpu: 200m
@@ -516,7 +516,7 @@ spec:
         - containerPort: 16110
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 160Mi
           limits:
             cpu: 200m
@@ -569,7 +569,7 @@ spec:
         - containerPort: 16111
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 160Mi
           limits:
             cpu: 200m
@@ -675,7 +675,7 @@ spec:
         - containerPort: 12386
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 160Mi
           limits:
             cpu: 200m
@@ -728,7 +728,7 @@ spec:
         - containerPort: 18855
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 160Mi
           limits:
             cpu: 200m
@@ -785,7 +785,7 @@ spec:
         - containerPort: 18856
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 160Mi
           limits:
             cpu: 200m
@@ -838,7 +838,7 @@ spec:
         - containerPort: 18673
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 160Mi
           limits:
             cpu: 200m
@@ -995,10 +995,10 @@ spec:
         - containerPort: 17853
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 160Mi
           limits:
-            cpu: 200m
+            cpu: 500m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -1048,7 +1048,7 @@ spec:
         - containerPort: 12032
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 160Mi
           limits:
             cpu: 200m
@@ -1101,7 +1101,7 @@ spec:
         - containerPort: 12031
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 160Mi
           limits:
             cpu: 500m
@@ -1154,10 +1154,10 @@ spec:
         - containerPort: 19001
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 160Mi
           limits:
-            cpu: 200m
+            cpu: 500m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -1211,10 +1211,10 @@ spec:
         - containerPort: 14569
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 160Mi
           limits:
-            cpu: 200m
+            cpu: 500m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -1269,10 +1269,10 @@ spec:
         - containerPort: 14568
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 160Mi
           limits:
-            cpu: 200m
+            cpu: 500m
             memory: 800Mi
         readinessProbe:
           tcpSocket:
@@ -1322,10 +1322,10 @@ spec:
         - containerPort: 16579
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 160Mi
           limits:
-            cpu: 200m
+            cpu: 500m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -1375,10 +1375,10 @@ spec:
         - containerPort: 18886
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 160Mi
           limits:
-            cpu: 200m
+            cpu: 500m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -1428,10 +1428,10 @@ spec:
         - containerPort: 14578
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 160Mi
           limits:
-            cpu: 200m
+            cpu: 500m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -1481,7 +1481,7 @@ spec:
         - containerPort: 11178
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 160Mi
           limits:
             cpu: 500m
@@ -1534,7 +1534,7 @@ spec:
         - containerPort: 18898
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 160Mi
           limits:
             cpu: 500m
@@ -1587,10 +1587,10 @@ spec:
         - containerPort: 11188
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 160Mi
           limits:
-            cpu: 200m
+            cpu: 500m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -1640,10 +1640,10 @@ spec:
         - containerPort: 12342
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 160Mi
           limits:
-            cpu: 200m
+            cpu: 500m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -1693,7 +1693,7 @@ spec:
         - containerPort: 12345
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 160Mi
           limits:
             cpu: 600m
@@ -1746,10 +1746,10 @@ spec:
         - containerPort: 16108
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 160Mi
           limits:
-            cpu: 200m
+            cpu: 500m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -1799,7 +1799,7 @@ spec:
         - containerPort: 15681
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 160Mi
           limits:
             cpu: 500m
@@ -1852,10 +1852,10 @@ spec:
         - containerPort: 14567
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 160Mi
           limits:
-            cpu: 200m
+            cpu: 500m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -1909,7 +1909,7 @@ spec:
             cpu: 100m
             memory: 200Mi
           limits:
-            cpu: 200m
+            cpu: 500m
             memory: 400Mi
         readinessProbe:
           tcpSocket:
@@ -1959,10 +1959,10 @@ spec:
         - containerPort: 14322
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 160Mi
           limits:
-            cpu: 200m
+            cpu: 500m
             memory: 500Mi
         readinessProbe:
           tcpSocket:
@@ -2120,7 +2120,7 @@ spec:
         - containerPort: 15678
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 160Mi
           limits:
             cpu: 200m
@@ -2169,7 +2169,7 @@ spec:
             cpu: 50m
             memory: 50Mi
           limits:
-            cpu: 50m
+            cpu: 100m
             memory: 50Mi
         readinessProbe:
           tcpSocket:
@@ -2209,7 +2209,7 @@ spec:
         - containerPort: 17001
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 200Mi
           limits:
             cpu: 200m

--- a/manifests/train-ticket-base/app/ts-part2.yaml
+++ b/manifests/train-ticket-base/app/ts-part2.yaml
@@ -38,7 +38,7 @@ spec:
         - containerPort: 18767
         resources:
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 100Mi
           limits:
             cpu: 200m
@@ -92,7 +92,7 @@ spec:
         - containerPort: 16112
         resources:
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 160Mi
           limits:
             cpu: 200m
@@ -198,7 +198,7 @@ spec:
         - containerPort: 16114
         resources:
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 160Mi
           limits:
             cpu: 200m
@@ -304,7 +304,7 @@ spec:
         - containerPort: 18888
         resources:
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 160Mi
           limits:
             cpu: 200m
@@ -357,7 +357,7 @@ spec:
         - containerPort: 15680
         resources:
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 160Mi
           limits:
             cpu: 500m
@@ -675,7 +675,7 @@ spec:
         - containerPort: 12386
         resources:
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 160Mi
           limits:
             cpu: 200m
@@ -728,7 +728,7 @@ spec:
         - containerPort: 18855
         resources:
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 160Mi
           limits:
             cpu: 200m
@@ -785,7 +785,7 @@ spec:
         - containerPort: 18856
         resources:
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 160Mi
           limits:
             cpu: 200m
@@ -838,7 +838,7 @@ spec:
         - containerPort: 18673
         resources:
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 160Mi
           limits:
             cpu: 200m
@@ -1587,7 +1587,7 @@ spec:
         - containerPort: 11188
         resources:
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 160Mi
           limits:
             cpu: 500m
@@ -1746,11 +1746,11 @@ spec:
         - containerPort: 16108
         resources:
           requests:
-            cpu: 100m
-            memory: 160Mi
+            cpu: 50m
+            memory: 100Mi
           limits:
             cpu: 500m
-            memory: 500Mi
+            memory: 300Mi
         readinessProbe:
           tcpSocket:
             port: 16108
@@ -2067,7 +2067,7 @@ spec:
           - containerPort: 18808
         resources:
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 100Mi
           limits:
             cpu: 500m
@@ -2120,7 +2120,7 @@ spec:
         - containerPort: 15678
         resources:
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 160Mi
           limits:
             cpu: 200m
@@ -2209,8 +2209,8 @@ spec:
         - containerPort: 17001
         resources:
           requests:
-            cpu: 100m
-            memory: 200Mi
+            cpu: 50m
+            memory: 160Mi
           limits:
             cpu: 200m
             memory: 500Mi

--- a/manifests/train-ticket-base/app/ts-part2.yaml
+++ b/manifests/train-ticket-base/app/ts-part2.yaml
@@ -1104,8 +1104,8 @@ spec:
             cpu: 100m
             memory: 160Mi
           limits:
-            cpu: 500m
-            memory: 500Mi
+            cpu: 800m
+            memory: 800Mi
         readinessProbe:
           tcpSocket:
             port: 12031

--- a/manifests/train-ticket-base/app/ts-part2.yaml
+++ b/manifests/train-ticket-base/app/ts-part2.yaml
@@ -46,7 +46,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 18767
-          initialDelaySeconds: 160
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
 ---
@@ -100,7 +100,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 16112
-          initialDelaySeconds: 160
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
 ---
@@ -153,7 +153,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 16113
-          initialDelaySeconds: 160
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
 ---
@@ -206,7 +206,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 16114
-          initialDelaySeconds: 160
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
 ---
@@ -259,7 +259,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 16115
-          initialDelaySeconds: 160
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
 ---
@@ -312,7 +312,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 18888
-          initialDelaySeconds: 160
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
 ---
@@ -365,7 +365,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 15680
-          initialDelaySeconds: 160
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
 ---
@@ -418,7 +418,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 18885
-          initialDelaySeconds: 160
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
 ---
@@ -471,7 +471,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 15679
-          initialDelaySeconds: 160
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
 ---
@@ -524,7 +524,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 16110
-          initialDelaySeconds: 160
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
 ---
@@ -577,7 +577,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 16111
-          initialDelaySeconds: 160
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
 ---
@@ -630,7 +630,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 12347
-          initialDelaySeconds: 160
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
 ---
@@ -683,7 +683,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 12386
-          initialDelaySeconds: 160
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
 ---
@@ -736,7 +736,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 18855
-          initialDelaySeconds: 160
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
 ---
@@ -793,7 +793,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 18856
-          initialDelaySeconds: 160
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
 ---
@@ -846,7 +846,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 18673
-          initialDelaySeconds: 160
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
 ---
@@ -900,7 +900,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 12340
-          initialDelaySeconds: 160
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
 ---
@@ -946,7 +946,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 12862
-          initialDelaySeconds: 160
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
 ---
@@ -1003,7 +1003,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 17853
-          initialDelaySeconds: 160
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
 ---
@@ -1056,7 +1056,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 12032
-          initialDelaySeconds: 160
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
 ---
@@ -1109,7 +1109,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 12031
-          initialDelaySeconds: 160
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
 ---
@@ -1162,7 +1162,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 19001
-          initialDelaySeconds: 160
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
 ---
@@ -1219,7 +1219,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 14569
-          initialDelaySeconds: 160
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
 ---
@@ -1277,7 +1277,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 14568
-          initialDelaySeconds: 160
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
 ---
@@ -1330,7 +1330,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 16579
-          initialDelaySeconds: 160
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
 ---
@@ -1383,7 +1383,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 18886
-          initialDelaySeconds: 160
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
 ---
@@ -1436,7 +1436,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 14578
-          initialDelaySeconds: 160
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
 ---
@@ -1489,7 +1489,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 11178
-          initialDelaySeconds: 160
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
 ---
@@ -1542,7 +1542,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 18898
-          initialDelaySeconds: 160
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
 ---
@@ -1595,7 +1595,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 11188
-          initialDelaySeconds: 160
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
 ---
@@ -1648,7 +1648,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 12342
-          initialDelaySeconds: 160
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
 ---
@@ -1701,7 +1701,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 12345
-          initialDelaySeconds: 160
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
 ---
@@ -1754,7 +1754,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 16108
-          initialDelaySeconds: 160
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
 ---
@@ -1807,7 +1807,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 15681
-          initialDelaySeconds: 160
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
 ---
@@ -1860,7 +1860,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 14567
-          initialDelaySeconds: 160
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
 ---
@@ -1914,7 +1914,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 16346
-          initialDelaySeconds: 160
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
 ---
@@ -1967,7 +1967,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 14322
-          initialDelaySeconds: 160
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
 ---
@@ -2021,7 +2021,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 12346
-          initialDelaySeconds: 160
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
 ---
@@ -2128,7 +2128,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 15678
-          initialDelaySeconds: 160
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
 ---
@@ -2174,7 +2174,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 16101
-          initialDelaySeconds: 160
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
 ---
@@ -2217,7 +2217,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 17001
-          initialDelaySeconds: 160
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
 ---

--- a/manifests/train-ticket-base/app/ts-part3.yaml
+++ b/manifests/train-ticket-base/app/ts-part3.yaml
@@ -32,10 +32,10 @@ spec:
         resources:
           requests:
             cpu: 50m
-            memory: 100Mi
+            memory: 50Mi
           limits:
             cpu: 500m
-            memory: 500Mi
+            memory: 200Mi
       - name: nginxlog-exporter
         image: ghcr.io/martin-helmich/prometheus-nginxlog-exporter/exporter:v1
         args: ["-config-file", "/etc/prometheus-nginxlog-exporter/nginxlog-exporter.config.hcl"]

--- a/manifests/train-ticket-base/app/ts-part3.yaml
+++ b/manifests/train-ticket-base/app/ts-part3.yaml
@@ -39,11 +39,8 @@ spec:
             cpu: 500m
             memory: 200Mi
       - name: nginxlog-exporter
-        image: ghcr.io/martin-helmich/prometheus-nginxlog-exporter/exporter:v1
-        args: [
-          "--parser", "json",
-          "-config-file", "/etc/prometheus-nginxlog-exporter/nginxlog-exporter.config.hcl",
-        ]
+        image: ghcr.io/martin-helmich/prometheus-nginxlog-exporter/exporter:v1.9.2
+        args: ["-config-file", "/etc/prometheus-nginxlog-exporter/nginxlog-exporter.config.hcl"]
         ports:
           - name: exporter
             containerPort: 4040

--- a/manifests/train-ticket-base/app/ts-part3.yaml
+++ b/manifests/train-ticket-base/app/ts-part3.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: ts-ui-dashboard
-        image: codewisdom/ts-ui-dashboard:0.2.0
+        image: codewisdom/ts-ui-dashboard:0.2.1
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080

--- a/manifests/train-ticket-base/app/ts-part3.yaml
+++ b/manifests/train-ticket-base/app/ts-part3.yaml
@@ -27,6 +27,8 @@ spec:
         ports:
         - containerPort: 8080
         volumeMounts:
+        - name: nginxconfig-vol
+          mountPath: /usr/local/openresty/nginx/conf/
         - name: nginxlog-vol
           mountPath: /usr/local/openresty/nginx/logs/
         resources:
@@ -38,7 +40,10 @@ spec:
             memory: 200Mi
       - name: nginxlog-exporter
         image: ghcr.io/martin-helmich/prometheus-nginxlog-exporter/exporter:v1
-        args: ["-config-file", "/etc/prometheus-nginxlog-exporter/nginxlog-exporter.config.hcl"]
+        args: [
+          "--parser", "json",
+          "-config-file", "/etc/prometheus-nginxlog-exporter/nginxlog-exporter.config.hcl",
+        ]
         ports:
           - name: exporter
             containerPort: 4040
@@ -48,6 +53,9 @@ spec:
         - name: nginxlog-exporter-config
           mountPath: /etc/prometheus-nginxlog-exporter
       volumes:
+      - name: nginxconfig-vol
+        configMap:
+          name: nginx-config
       - name: nginxlog-vol
         emptyDir: {}
       - name: nginxlog-exporter-config

--- a/manifests/train-ticket-base/app/ts-ui-dashboard.nginx/mime.types
+++ b/manifests/train-ticket-base/app/ts-ui-dashboard.nginx/mime.types
@@ -1,0 +1,98 @@
+types {
+    text/html                                        html htm shtml;
+    text/css                                         css;
+    text/xml                                         xml;
+    image/gif                                        gif;
+    image/jpeg                                       jpeg jpg;
+    application/javascript                           js;
+    application/atom+xml                             atom;
+    application/rss+xml                              rss;
+
+    text/mathml                                      mml;
+    text/plain                                       txt;
+    text/vnd.sun.j2me.app-descriptor                 jad;
+    text/vnd.wap.wml                                 wml;
+    text/x-component                                 htc;
+
+    image/avif                                       avif;
+    image/png                                        png;
+    image/svg+xml                                    svg svgz;
+    image/tiff                                       tif tiff;
+    image/vnd.wap.wbmp                               wbmp;
+    image/webp                                       webp;
+    image/x-icon                                     ico;
+    image/x-jng                                      jng;
+    image/x-ms-bmp                                   bmp;
+
+    font/woff                                        woff;
+    font/woff2                                       woff2;
+
+    application/java-archive                         jar war ear;
+    application/json                                 json;
+    application/mac-binhex40                         hqx;
+    application/msword                               doc;
+    application/pdf                                  pdf;
+    application/postscript                           ps eps ai;
+    application/rtf                                  rtf;
+    application/vnd.apple.mpegurl                    m3u8;
+    application/vnd.google-earth.kml+xml             kml;
+    application/vnd.google-earth.kmz                 kmz;
+    application/vnd.ms-excel                         xls;
+    application/vnd.ms-fontobject                    eot;
+    application/vnd.ms-powerpoint                    ppt;
+    application/vnd.oasis.opendocument.graphics      odg;
+    application/vnd.oasis.opendocument.presentation  odp;
+    application/vnd.oasis.opendocument.spreadsheet   ods;
+    application/vnd.oasis.opendocument.text          odt;
+    application/vnd.openxmlformats-officedocument.presentationml.presentation
+                                                     pptx;
+    application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+                                                     xlsx;
+    application/vnd.openxmlformats-officedocument.wordprocessingml.document
+                                                     docx;
+    application/vnd.wap.wmlc                         wmlc;
+    application/wasm                                 wasm;
+    application/x-7z-compressed                      7z;
+    application/x-cocoa                              cco;
+    application/x-java-archive-diff                  jardiff;
+    application/x-java-jnlp-file                     jnlp;
+    application/x-makeself                           run;
+    application/x-perl                               pl pm;
+    application/x-pilot                              prc pdb;
+    application/x-rar-compressed                     rar;
+    application/x-redhat-package-manager             rpm;
+    application/x-sea                                sea;
+    application/x-shockwave-flash                    swf;
+    application/x-stuffit                            sit;
+    application/x-tcl                                tcl tk;
+    application/x-x509-ca-cert                       der pem crt;
+    application/x-xpinstall                          xpi;
+    application/xhtml+xml                            xhtml;
+    application/xspf+xml                             xspf;
+    application/zip                                  zip;
+
+    application/octet-stream                         bin exe dll;
+    application/octet-stream                         deb;
+    application/octet-stream                         dmg;
+    application/octet-stream                         iso img;
+    application/octet-stream                         msi msp msm;
+
+    audio/midi                                       mid midi kar;
+    audio/mpeg                                       mp3;
+    audio/ogg                                        ogg;
+    audio/x-m4a                                      m4a;
+    audio/x-realaudio                                ra;
+
+    video/3gpp                                       3gpp 3gp;
+    video/mp2t                                       ts;
+    video/mp4                                        mp4;
+    video/mpeg                                       mpeg mpg;
+    video/quicktime                                  mov;
+    video/webm                                       webm;
+    video/x-flv                                      flv;
+    video/x-m4v                                      m4v;
+    video/x-mng                                      mng;
+    video/x-ms-asf                                   asx asf;
+    video/x-ms-wmv                                   wmv;
+    video/x-msvideo                                  avi;
+}

--- a/manifests/train-ticket-base/app/ts-ui-dashboard.nginx/nginx.conf
+++ b/manifests/train-ticket-base/app/ts-ui-dashboard.nginx/nginx.conf
@@ -319,7 +319,7 @@ http {
 
     #For Food
     location ^~ /api/v1/foodservice {
-            proxy_pass http://ts-food-service:18856;
+      proxy_pass http://ts-food-service:18856;
     }
 
     location /api/v1/foodservice/foods {

--- a/manifests/train-ticket-base/app/ts-ui-dashboard.nginx/nginx.conf
+++ b/manifests/train-ticket-base/app/ts-ui-dashboard.nginx/nginx.conf
@@ -1,0 +1,402 @@
+worker_processes  1;
+error_log logs/error.log;
+events {
+  worker_connections 1024;
+}
+http {
+
+  include mime.types;
+  default_type  application/octet-stream;
+
+  log_format main  '$remote_addr - $remote_user [$time_local] "$request" $request_length $status $body_bytes_sent $request_time "$http_referer" "$http_user_agent" "$http_x_forwarded_for" $upstream_response_time';
+
+  log_format json escape=json '{"time": "$time_iso8601",'
+    '"remote_addr": "$remote_addr",'
+    '"status": "$status",'
+    '"request": "$request",'
+    '"request_method": "$request_method",'
+    '"request_length": "$request_length",'
+    '"request_time": "$request_time",'
+    '"body_bytes_sent": "$body_bytes_sent",'
+    '"upstream_response_time": "$upstream_response_time"}';
+
+  access_log  logs/access.log  main;
+
+  sendfile        on;
+  #tcp_nopush     on;
+
+  #keepalive_timeout  0;
+  keepalive_timeout  35;
+
+  #gzip  on;
+
+  server {
+    listen 8080;
+    proxy_http_version 1.1;
+    proxy_set_header Connection "";
+
+    location / {
+      root   /usr/share/nginx/html;
+      index  index.html index.htm;
+    }
+
+    location ~* \.(html)$ {
+      root /usr/share/nginx/html;
+    }
+
+
+    # For travel service
+    location /api/v1/travelservice/trips/left {
+      proxy_pass   http://ts-travel-service:12346;
+    }
+    # For travel2 service
+    location /api/v1/travel2service/trips/left {
+      proxy_pass   http://ts-travel2-service:16346;
+    }
+
+    # For account and verification
+    location /api/v1/userservice/users {
+      proxy_pass   http://ts-user-service:12342;
+    }
+    location /api/v1/users/auth {
+      proxy_pass   http://ts-auth-service:12340;
+    }
+
+    location /api/v1/users/login {
+      proxy_pass   http://ts-auth-service:12340;
+    }
+
+    location /api/v1/verifycode/generate {
+      proxy_ignore_client_abort on ;
+      proxy_pass   http://ts-verification-code-service:15678;
+    }
+
+
+    # For station service
+    location /api/v1/stationservice {
+      proxy_pass   http://ts-station-service:12345;
+    }
+
+    # For train service
+    location /api/v1/trainservice {
+      proxy_pass   http://ts-train-service:14567;
+    }
+
+    # For config service
+    location /api/v1/configservice {
+      proxy_pass   http://ts-config-service:15679;
+    }
+
+    # For security service
+
+    location /api/v1/securityservice {
+      proxy_pass   http://ts-security-service:11188;
+    }
+
+    # For Execute service
+
+    location /api/v1/executeservice/execute/execute {
+      proxy_pass   http://ts-execute-service:12386;
+    }
+    location /api/v1/executeservice/execute/collected {
+      proxy_pass   http://ts-execute-service:12386;
+    }
+
+
+    # For contacts service
+
+    location /api/v1/contactservice/contacts {
+      proxy_pass   http://ts-contacts-service:12347;
+    }
+
+    location /api/v1/contactservice/contacts/account {
+      proxy_pass   http://ts-contacts-service:12347;
+    }
+
+
+    # For order service
+    location /api/v1/orderservice/order/refresh {
+      proxy_pass   http://ts-order-service:12031;
+    }
+
+    # For order other service
+
+    location /api/v1/orderOtherService/orderOther/refresh {
+      proxy_pass   http://ts-order-other-service:12032;
+    }
+
+    #For preserve service
+
+    location /api/v1/preserveservice/preserve {
+      proxy_pass   http://ts-preserve-service:14568;
+    }
+
+    #For preserve other service
+
+    location /api/v1/preserveotherservice/preserveOther {
+      proxy_pass   http://ts-preserve-other-service:14569;
+    }
+
+
+    #For price service
+    location /price/query {
+      proxy_pass  http://ts-price-service:16579;
+    }
+    location /price/queryAll {
+      proxy_pass  http://ts-price-service:16579;
+    }
+    location /price/create {
+      proxy_pass  http://ts-price-service:16579;
+    }
+    location /price/delete {
+      proxy_pass  http://ts-price-service:16579;
+    }
+    location /price/update {
+      proxy_pass  http://ts-price-service:16579;
+    }
+
+    #For basic information service
+    location /basic/queryForTravel {
+      proxy_pass  http://ts-basic-service:15680;
+    }
+
+    #For ticket information service
+    location /ticketinfo/queryForTravel {
+      proxy_pass  http://ts-ticketinfo-service:15681;
+    }
+
+    #For notification service
+    location /notification/preserve_success {
+      proxy_pass  http://ts-notification-service:17853;
+    }
+    location /notification/order_create_success {
+      proxy_pass  http://ts-notification-service:17853;
+    }
+    location /notification/order_changed_success {
+      proxy_pass  http://ts-notification-service:17853;
+    }
+
+    #For inside payment service
+    location /api/v1/inside_pay_service/inside_payment {
+      proxy_pass  http://ts-inside-payment-service:18673;
+    }
+
+
+    #For payment service
+    location /payment/pay {
+      proxy_pass  http://ts-payment-service:19001;
+    }
+    location /payment/addMoney {
+      proxy_pass  http://ts-payment-service:19001;
+    }
+    location /payment/query {
+      proxy_pass  http://ts-payment-service:19001;
+    }
+
+    #For rebook service
+    location /rebook {
+      proxy_pass  http://ts-rebook-service:18886;
+    }
+
+    #For cancel Order
+    location /api/v1/cancelservice/cancel {
+      proxy_pass  http://ts-cancel-service:18885;
+    }
+    location /api/v1/cancelservice/cancel/refound {
+      proxy_pass  http://ts-cancel-service:18885;
+    }
+    #For station name
+    location /api/v1/stationservice/stations/name {
+      proxy_pass  http://ts-station-service:12345;
+    }
+
+    #For rebook
+    location /api/v1/rebookservice/rebook  {
+      proxy_pass  http://ts-rebook-service:18886;
+    }
+    location /api/v1/rebookservice/rebook/difference {
+      proxy_pass  http://ts-rebook-service:18886;
+    }
+
+    #For Route
+    location /route/createAndModify {
+      proxy_pass  http://ts-route-service:11178;
+    }
+    location /route/delete {
+      proxy_pass  http://ts-route-service:11178;
+    }
+    location /route/queryAll {
+      proxy_pass  http://ts-route-service:11178;
+    }
+    location /route/queryById {
+      proxy_pass  http://ts-route-service:11178;
+    }
+    location /route/queryByStartAndTerminal {
+      proxy_pass  http://ts-route-service:11178;
+    }
+
+    #For Assurance
+    location /api/v1/assuranceservice/assurances/types {
+      proxy_pass  http://ts-assurance-service:18888;
+    }
+    location /assurance/getAssuranceById {
+      proxy_pass  http://ts-assurance-service:18888;
+    }
+    location /assurance/findAssuranceByOrderId {
+      proxy_pass  http://ts-assurance-service:18888;
+    }
+    location /assurance/findAll {
+      proxy_pass  http://ts-assurance-service:18888;
+    }
+    location /assurance/create {
+      proxy_pass  http://ts-assurance-service:18888;
+    }
+    location /assurance/deleteAssurance {
+      proxy_pass  http://ts-assurance-service:18888;
+    }
+    location /assurance/deleteAssuranceByOrderId {
+      proxy_pass  http://ts-assurance-service:18888;
+    }
+    location /assurance/modifyAssurance {
+      proxy_pass  http://ts-assurance-service:18888;
+    }
+
+    #For Ticket Office
+    location /office/getRegionList {
+      proxy_pass  http://ts-ticket-office-service:16108;
+    }
+    location /office/getAll {
+      proxy_pass  http://ts-ticket-office-service:16108;
+    }
+    location /office/getSpecificOffices {
+      proxy_pass  http://ts-ticket-office-service:16108;
+    }
+    location /office/addOffice {
+      proxy_pass  http://ts-ticket-office-service:16108;
+    }
+    location /office/deleteOffice {
+      proxy_pass  http://ts-ticket-office-service:16108;
+    }
+    location /office/updateOffice {
+      proxy_pass  http://ts-ticket-office-service:16108;
+    }
+
+    #For Travel Transit
+    location /travelPlan/getTransferResult {
+      proxy_pass  http://ts-travel-plan-service:14322;
+    }
+    location /api/v1/travelplanservice/travelPlan/cheapest {
+      proxy_pass  http://ts-travel-plan-service:14322;
+    }
+    location /api/v1/travelplanservice/travelPlan/quickest {
+      proxy_pass  http://ts-travel-plan-service:14322;
+    }
+    location /api/v1/travelplanservice/travelPlan/minStation {
+      proxy_pass  http://ts-travel-plan-service:14322;
+    }
+
+    #For Consign and Voucher
+    location /api/v1/consignservice/consigns {
+      proxy_pass  http://ts-consign-service:16111;
+    }
+    location /api/v1/consignservice/consigns/account {
+      proxy_pass  http://ts-consign-service:16111;
+    }
+    location /getVoucher {
+      proxy_pass  http://ts-voucher-service:16101;
+    }
+
+    #For Route Plan
+    location /routePlan/minStopStations {
+      proxy_pass  http://ts-route-plan-service:14578;
+    }
+    location /routePlan/cheapestRoute {
+      proxy_pass  http://ts-route-plan-service:14578;
+    }
+    location /routePlan/quickestRoute {
+      proxy_pass  http://ts-route-plan-service:14578;
+    }
+
+    #For Food
+    location ^~ /api/v1/foodservice {
+            proxy_pass http://ts-food-service:18856;
+    }
+
+    location /api/v1/foodservice/foods {
+      proxy_pass http://ts-food-service:18856;
+    }
+    location /food/createFoodOrder {
+      proxy_pass http://ts-food-service:18856;
+    }
+    location /food/cancelFoodOrder {
+      proxy_pass http://ts-food-service:18856;
+    }
+    location /food/updateFoodOrder {
+      proxy_pass http://ts-food-service:18856;
+    }
+    location /food/findAllFoodOrder {
+      proxy_pass http://ts-food-service:18856;
+    }
+    location /food/findFoodOrderByOrderId {
+      proxy_pass http://ts-food-service:18856;
+    }
+
+    #For Food
+    location /news-service/news {
+      proxy_pass http://ts-news-service:12862;
+    }
+
+    #For Admin basic info
+    location /api/v1/adminbasicservice/adminbasic/contacts {
+      proxy_pass http://ts-admin-basic-info-service:18767;
+    }
+
+    location /api/v1/adminbasicservice/adminbasic/stations {
+      proxy_pass http://ts-admin-basic-info-service:18767;
+    }
+
+
+    location /api/v1/adminbasicservice/adminbasic/trains {
+      proxy_pass http://ts-admin-basic-info-service:18767;
+    }
+
+
+    location /api/v1/adminbasicservice/adminbasic/prices {
+      proxy_pass http://ts-admin-basic-info-service:18767;
+    }
+
+
+    location /api/v1/adminbasicservice/adminbasic/configs {
+      proxy_pass http://ts-admin-basic-info-service:18767;
+    }
+
+
+    #For Admin Order
+    location /api/v1/adminorderservice/adminorder {
+      proxy_pass http://ts-admin-order-service:16112;
+    }
+
+
+    #For Admin Route
+    location /api/v1/adminrouteservice/adminroute {
+      proxy_pass http://ts-admin-route-service:16113;
+    }
+
+
+    #For Admin Travel
+    location /api/v1/admintravelservice/admintravel {
+      proxy_pass http://ts-admin-travel-service:16114;
+    }
+
+
+    #For Admin User
+    location /api/v1/adminuserservice/users {
+      proxy_pass http://ts-admin-user-service:16115;
+    }
+
+    #For Avatar Service
+    location /api/v1/avatar {
+      proxy_pass http://ts-avatar-service:17001;
+    }
+  }
+}

--- a/manifests/train-ticket-base/helmfile.yaml
+++ b/manifests/train-ticket-base/helmfile.yaml
@@ -8,7 +8,7 @@ releases:
   - name: chaos
     namespace: litmus
     chart: litmuschaos/litmus
-    version: ~2.10.1
+    version: ~2.10.0
     values:
       - mongo:
           nodeSelector:

--- a/manifests/train-ticket-base/helmfile.yaml
+++ b/manifests/train-ticket-base/helmfile.yaml
@@ -8,14 +8,25 @@ releases:
   - name: chaos
     namespace: litmus
     chart: litmuschaos/litmus
-    version: ~2.9.0
+    version: ~2.10.1
     values:
-      - nodeSelector:
-          cloud.google.com/gke-nodepool: control-pool
+      - mongo:
+          nodeSelector:
+            cloud.google.com/gke-nodepool: control-pool
+      - portal:
+          frontend:
+            nodeSelector:
+              cloud.google.com/gke-nodepool: control-pool
+          server:
+            nodeSelector:
+              cloud.google.com/gke-nodepool: control-pool
+          upgradeAgent:
+            nodeSelector:
+              cloud.google.com/gke-nodepool: control-pool
   - name: kubernetes-chaos
     namespace: litmus
     chart: litmuschaos/kubernetes-chaos
-    version: ~2.23.0
+    version: ~2.24.0
     values:
       - image:
           litmusGO:

--- a/manifests/train-ticket-base/loadtest/locustfile.py
+++ b/manifests/train-ticket-base/loadtest/locustfile.py
@@ -358,7 +358,7 @@ def get_voucher(client, user_id):
 
 
 class UserNoLogin(HttpUser):
-    weight = 1
+    weight = 2
 
     def on_start(self):
         self.client.headers.update({"Content-Type": "application/json"})

--- a/manifests/train-ticket-base/loadtest/locustfile.py
+++ b/manifests/train-ticket-base/loadtest/locustfile.py
@@ -56,7 +56,10 @@ def request_post_to_api(client, url, body, name, headers={}):
             response.failure(
                 f"failed to request status:{response.status_code} body:{response.content.decode('UTF-8')[0:10]}")
     response_as_json = response.json()
-    return response_as_json, response_as_json["status"]
+    if 'status' in response_as_json:
+        return response_as_json, response_as_json["status"]
+    else:
+        return response_as_json, 1
 
 
 def try_until_success(f):

--- a/manifests/train-ticket-base/loadtest/locustfile.py
+++ b/manifests/train-ticket-base/loadtest/locustfile.py
@@ -166,8 +166,7 @@ def get_departure_date():
     # We always start next Monday because there a train from Shang Hai to Su Zhou starts.
     tomorrow = datetime.now() + timedelta(1)
     next_monday = next_weekday(tomorrow, 0)
-    departure_date = next_monday.strftime("%Y-%m-%d")
-    return departure_date
+    return next_monday.strftime("%Y-%m-%d")
 
 
 def get_trip_information(client, from_station, to_station):
@@ -293,10 +292,11 @@ def cancel(client, user_id):
 
 
 def consign(client, user_id):
-    departure_date = get_departure_date()
     order_id = get_last_order_id(client, user_id, STATUS_BOOKED)
     if order_id is None:
         raise Exception("Weird... There is no order to consign.")
+
+    departure_date = get_departure_date()
 
     def api_call_consign():
         body = {
@@ -358,7 +358,7 @@ def get_voucher(client, user_id):
 
 
 class UserNoLogin(HttpUser):
-    weight = 50
+    weight = 1
 
     def on_start(self):
         self.client.headers.update({"Content-Type": "application/json"})
@@ -375,7 +375,7 @@ class UserNoLogin(HttpUser):
 
 
 class UserBooking(HttpUser):
-    weight = 10
+    weight = 1
 
     def on_start(self):
         user_id, token = login(self.client)
@@ -398,7 +398,7 @@ class UserBooking(HttpUser):
 
 
 class UserConsignTicket(HttpUser):
-    weight = 5
+    weight = 1
 
     def on_start(self):
         user_id, token = login(self.client)

--- a/manifests/train-ticket-base/loadtest/locustfile.py
+++ b/manifests/train-ticket-base/loadtest/locustfile.py
@@ -377,7 +377,7 @@ class UserNoLogin(HttpUser):
 class UserBooking(HttpUser):
     weight = 1
 
-    def on_start(self):
+    def _login(self):
         user_id, token = login(self.client)
         self.client.headers.update({"Authorization": f"Bearer {token}"})
         self.client.headers.update({"Content-Type": "application/json"})
@@ -386,6 +386,8 @@ class UserBooking(HttpUser):
 
     @task
     def perform_task(self):
+        self._login()
+
         request_id = str(uuid.uuid4())
         logging.debug(f'Running user "booking" with request id {request_id}...')
 
@@ -400,7 +402,7 @@ class UserBooking(HttpUser):
 class UserConsignTicket(HttpUser):
     weight = 1
 
-    def on_start(self):
+    def _login(self):
         user_id, token = login(self.client)
         self.client.headers.update({"Authorization": f"Bearer {token}"})
         self.client.headers.update({"Content-Type": "application/json"})
@@ -409,6 +411,8 @@ class UserConsignTicket(HttpUser):
 
     @task
     def perform_task(self):
+        self._login()
+
         request_id = str(uuid.uuid4())
         logging.debug(f'Running user "consign ticket" with request id {request_id}...')
 
@@ -422,7 +426,7 @@ class UserConsignTicket(HttpUser):
 class UserCancelNoRefund(HttpUser):
     weight = 1
 
-    def on_start(self):
+    def _login(self):
         user_id, token = login(self.client)
         self.client.headers.update({"Authorization": f"Bearer {token}"})
         self.client.headers.update({"Content-Type": "application/json"})
@@ -431,6 +435,8 @@ class UserCancelNoRefund(HttpUser):
 
     @task
     def perform_task(self):
+        self._login()
+
         request_id = str(uuid.uuid4())
         logging.debug(f'Running user "cancel no refund" with request id {request_id}...')
 
@@ -444,7 +450,7 @@ class UserCancelNoRefund(HttpUser):
 class UserRefundVoucher(HttpUser):
     weight = 1
 
-    def on_start(self):
+    def _login(self):
         user_id, token = login(self.client)
         self.client.headers.update({"Authorization": f"Bearer {token}"})
         self.client.headers.update({"Content-Type": "application/json"})
@@ -453,6 +459,8 @@ class UserRefundVoucher(HttpUser):
 
     @task
     def perform_task(self):
+        self._login()
+
         request_id = str(uuid.uuid4())
         logging.debug(f'Running user "cancel no refund" with request id {request_id}...')
 

--- a/manifests/train-ticket-overlays/single-replica/loadtest.yaml
+++ b/manifests/train-ticket-overlays/single-replica/loadtest.yaml
@@ -13,6 +13,6 @@ spec:
       - name: load-test-master
         env:
           - name: LOCUST_USERS
-            value: '100'
+            value: '20'
           - name: LOCUST_SPAWN_RATE
             value: '1'


### PR DESCRIPTION
- manifests: bump train ticket version 0.2.0 -> 0.2.1
- manifests: change initialDelaySeconds 160 -> 60
- manifests: increase cpu limits of apps in train tickets
- manifests: fix cpu limits
- manifests: support the case that the response doesn't have 'status' in locustfile
- manifests: revert unbalanced weights in locustfile
- manifests: fix label name of ts-config-price-service
- manifests: set nodeSelector for litmus
- manifests: decrease the number of locust users
- manifests: fix upgrade failure
- manifests: include response time in nginx access.log
- manifests: export ts-ui-dashboard response time metrics from nginx access log
- manifests: adjust memory resource
- manifests: increase UserNoLogin weight
- manifests: remove jaeger-related resources
- manifests: avoid token expired exception in an hour
- manifests: add label of http request path in nginxlog-exporter
- manifests: adjust web resource
- manifests: fix indent
